### PR TITLE
Fix numeric input arguments

### DIFF
--- a/src/TQ/Git/Cli/Binary.php
+++ b/src/TQ/Git/Cli/Binary.php
@@ -109,7 +109,7 @@ class Binary
     {
         $handleArg  = function($key, $value) {
             $key  = ltrim($key, '-');
-            if (strlen($key) == 1) {
+            if (strlen($key) == 1 || is_numeric($key)) {
                 $arg = sprintf('-%s', escapeshellarg($key));
                 if ($value !== null) {
                     $arg    .= ' '.escapeshellarg($value);

--- a/tests/TQ/Tests/Git/Repository/InfoTest.php
+++ b/tests/TQ/Tests/Git/Repository/InfoTest.php
@@ -143,6 +143,10 @@ class InfoTest extends \PHPUnit_Framework_TestCase
         $log    = $c->getLog(1, 1);
         $this->assertEquals(1, count($log));
         $this->assertContains('Initial commit', $log[0]);
+
+        $log    = $c->getLog(10,0);
+        $this->assertEquals(2, count($log));
+        $this->assertContains('Initial commit', $log[1]);
     }
 
     public function testShowCommit()


### PR DESCRIPTION
getLog() throws exceptions since the argument check has been prefixing it with another "-" 
