### PR TITLE
Adds named arguments and implements them in getLog()

### DIFF
--- a/src/TQ/Git/Repository/Repository.php
+++ b/src/TQ/Git/Repository/Repository.php
@@ -447,6 +447,8 @@ class Repository extends AbstractRepository
                 $noValue = true;
             } elseif (is_bool($value)) {
                 $noValue = true;
+            } elseif (is_null($value)) {
+                continue;
             } else {
                 $noValue = false;
             }

--- a/tests/TQ/Tests/Git/Repository/InfoTest.php
+++ b/tests/TQ/Tests/Git/Repository/InfoTest.php
@@ -153,6 +153,10 @@ class InfoTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, count($log));
         $this->assertContains('Initial commit', $log[1]);
 
+        $log    = $c->getLog(null, null);
+        $this->assertEquals(2, count($log));
+        $this->assertContains('Initial commit', $log[1]);
+
         $hash2 = $c->writeFile('file7.txt', 'Test create file 7', 'Test create file 7');
         $hash3 = $c->writeFile('file8.txt', 'Test create file 8', 'Test create file 8');
 


### PR DESCRIPTION
Implements named arguments and adds supports for most of the arguments to git-log.  Usage is demonstrated in the unit tests.  My main use case is for setting up JSON input/output for REST APIs, along with some CLI management tools.

This ended up not needing to impact the function signatures directly, as using func_get_args to do parsing ended up being cleanest way to go.

It's a bit clunky having the argument parsers smack in the middle of the git repo class; there aren't any dependencies in it.  Do you have a better spot in mind for them?
