### PR TITLE
Return the correct remote results

### DIFF
--- a/src/TQ/Git/Repository/Repository.php
+++ b/src/TQ/Git/Repository/Repository.php
@@ -3,7 +3,7 @@
  * Copyright (C) 2014 by TEQneers GmbH & Co. KG
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to dealgetCurrentRemote
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is


### PR DESCRIPTION
Right now it just returns the last remote. This is an issue if you have multiple remotes.

This changes the output from:

``` php
Array
(
    [fetch] => Array
        (
            [origin] => git@github.com:ericduran/PHP-Stream-Wrapper-for-Git.git
        )

    [push] => Array
        (
            [origin] => git@github.com:ericduran/PHP-Stream-Wrapper-for-Git.git
        )

)
```

to:

``` php
Array
(
    [ericduran] => Array
        (
            [fetch] => git@github.com:ericduran/PHP-Stream-Wrapper-for-Git.git
            [push] => git@github.com:ericduran/PHP-Stream-Wrapper-for-Git.git
        )

    [origin] => Array
        (
            [fetch] => git@github.com:teqneers/PHP-Stream-Wrapper-for-Git.git
            [push] => git@github.com:teqneers/PHP-Stream-Wrapper-for-Git.git
        )

)
```
