### PR TITLE
Repository Open Argument Flag Added for Finding Repository Root

### DIFF
--- a/src/TQ/Git/Repository/Repository.php
+++ b/src/TQ/Git/Repository/Repository.php
@@ -71,13 +71,14 @@ class Repository extends AbstractRepository
      * @param   boolean|integer      $createIfNotExists     False to fail on non-existing repositories, directory
      *                                                      creation mode, such as 0755  if the command
      *                                                      should create the directory and init the repository instead
-     * @param   array|null           $initArguments         Arguments to be passed to git-init if initializing a
-     *                                                      repository
+     * @param   string|null          $repositoryRoot        The full path of the repository root path to avoid bubbling 
+     *                                                      up the repository path looking for the .git directory.
+     *
      * @return  Repository
      * @throws  \RuntimeException                       If the path cannot be created
      * @throws  \InvalidArgumentException               If the path is not valid or if it's not a valid Git repository
      */
-    public static function open($repositoryPath, $git = null, $createIfNotExists = false, $initArguments = null)
+    public static function open($repositoryPath, $git = null, $createIfNotExists = false, $repositoryRoot = null)
     {
         $git = Binary::ensure($git);
 
@@ -87,7 +88,9 @@ class Repository extends AbstractRepository
             ));
         }
 
-        $repositoryRoot = self::findRepositoryRoot($repositoryPath);
+        if ($repositoryRoot === null) {
+            $repositoryRoot = self::findRepositoryRoot($repositoryPath);
+        }
 
         if ($repositoryRoot === null) {
             if (!$createIfNotExists) {
@@ -104,7 +107,7 @@ class Repository extends AbstractRepository
                         '"%s" is not a valid path', $repositoryPath
                     ));
                 }
-                self::initRepository($git, $repositoryPath, $initArguments);
+                self::initRepository($git, $repositoryPath);
                 $repositoryRoot = $repositoryPath;
             }
         }

--- a/src/TQ/Git/Repository/Repository.php
+++ b/src/TQ/Git/Repository/Repository.php
@@ -63,7 +63,7 @@ class Repository extends AbstractRepository
      */
     protected $git;
 
-    /**
+        /**
      * Opens a Git repository on the file system, optionally creates and initializes a new repository
      *
      * @param   string               $repositoryPath        The full path to the repository
@@ -73,15 +73,16 @@ class Repository extends AbstractRepository
      *                                                      should create the directory and init the repository instead
      * @param   array|null           $initArguments         Arguments to be passed to git-init if initializing a
      *                                                      repository
-     * @param   string|null          $repositoryRoot        The full path of the repository root path to avoid bubbling 
-     *                                                      up the repository path looking for the .git directory.
+     * @param   boolean              $findRepositoryRoot    False to use the repository path as the root directory.
+     *
      * @return  Repository
      * @throws  \RuntimeException                       If the path cannot be created
      * @throws  \InvalidArgumentException               If the path is not valid or if it's not a valid Git repository
      */
-    public static function open($repositoryPath, $git = null, $createIfNotExists = false, $initArguments = null, $repositoryRoot = null)
+    public static function open($repositoryPath, $git = null, $createIfNotExists = false, $initArguments = null, $findRepositoryRoot = true)
     {
         $git = Binary::ensure($git);
+        $repositoryRoot = null;
 
         if (!is_string($repositoryPath)) {
             throw new \InvalidArgumentException(sprintf(
@@ -89,7 +90,7 @@ class Repository extends AbstractRepository
             ));
         }
 
-        if ($repositoryRoot === null) {
+        if ($findRepositoryRoot) {
             $repositoryRoot = self::findRepositoryRoot($repositoryPath);
         }
 

--- a/src/TQ/Git/Repository/Repository.php
+++ b/src/TQ/Git/Repository/Repository.php
@@ -71,14 +71,15 @@ class Repository extends AbstractRepository
      * @param   boolean|integer      $createIfNotExists     False to fail on non-existing repositories, directory
      *                                                      creation mode, such as 0755  if the command
      *                                                      should create the directory and init the repository instead
+     * @param   array|null           $initArguments         Arguments to be passed to git-init if initializing a
+     *                                                      repository
      * @param   string|null          $repositoryRoot        The full path of the repository root path to avoid bubbling 
      *                                                      up the repository path looking for the .git directory.
-     *
      * @return  Repository
      * @throws  \RuntimeException                       If the path cannot be created
      * @throws  \InvalidArgumentException               If the path is not valid or if it's not a valid Git repository
      */
-    public static function open($repositoryPath, $git = null, $createIfNotExists = false, $repositoryRoot = null)
+    public static function open($repositoryPath, $git = null, $createIfNotExists = false, $initArguments = null, $repositoryRoot = null)
     {
         $git = Binary::ensure($git);
 
@@ -107,7 +108,7 @@ class Repository extends AbstractRepository
                         '"%s" is not a valid path', $repositoryPath
                     ));
                 }
-                self::initRepository($git, $repositoryPath);
+                self::initRepository($git, $repositoryPath, $initArguments);
                 $repositoryRoot = $repositoryPath;
             }
         }


### PR DESCRIPTION
Git repositories can be hierarchically structured and specifically ignored by the parent.  This change forces the Repository::open method to use the repository path as the root path instead of bubbling through the repository path looking for a parent.