### PR TITLE
Fix getCurrentBranch() not always returning the current branch name

### DIFF
--- a/src/TQ/Git/Repository/Repository.php
+++ b/src/TQ/Git/Repository/Repository.php
@@ -968,8 +968,9 @@ class Repository extends AbstractRepository
     public function getCurrentBranch()
     {
         /** @var $result CallResult */
-        $result = $this->getGit()->{'name-rev'}($this->getRepositoryPath(), array(
-            '--name-only',
+        $result = $this->getGit()->{'rev-parse'}($this->getRepositoryPath(), array(
+            '--symbolic-full-name',
+            '--abbrev-ref',
             'HEAD'
         ));
         $result->assertSuccess(


### PR DESCRIPTION
Per https://gist.github.com/kaspter/2595598