### PR TITLE
Fix git throwing an error when pathspec is empty

### DIFF
--- a/src/TQ/Git/Repository/Repository.php
+++ b/src/TQ/Git/Repository/Repository.php
@@ -1047,4 +1047,19 @@ class Repository extends AbstractRepository
 
         return $retVar;
     }
+
+    /**
+     * Resolves an absolute path into a path relative to the repository path
+     *
+     * @param   string|array  $path         A file system path (or an array of paths)
+     * @return  string|array                Either a single path or an array of paths is returned
+     */
+    public function resolveLocalPath($path)
+    {
+        $path = parent::resolveLocalPath($path);
+        if ($path === '') {
+            $path = '.';
+        }
+        return $path;
+    }
 }


### PR DESCRIPTION
Since git `2.16` the pathspec should not be empty (see https://github.com/git/git/blob/master/Documentation/RelNotes/2.16.0.txt).

When using PHP's [`RecursiveDirectoryIterator`](http://php.net/manual/de/recursivedirectoryiterator.construct.php) an exemption will be thrown because it tries to access `''`.