### PR TITLE
Revert "Fix git throwing an error when pathspec is empty"

### DIFF
--- a/src/TQ/Git/Repository/Repository.php
+++ b/src/TQ/Git/Repository/Repository.php
@@ -1048,19 +1048,4 @@ class Repository extends AbstractRepository
 
         return $retVar;
     }
-
-    /**
-     * Resolves an absolute path into a path relative to the repository path
-     *
-     * @param   string|array  $path         A file system path (or an array of paths)
-     * @return  string|array                Either a single path or an array of paths is returned
-     */
-    public function resolveLocalPath($path)
-    {
-        $path = parent::resolveLocalPath($path);
-        if ($path === '') {
-            $path = '.';
-        }
-        return $path;
-    }
 }


### PR DESCRIPTION
Reverts teqneers/PHP-Stream-Wrapper-for-Git#26

One failing test was indeed caused by the PR. Please investigate.