### PR TITLE
Fix pathspec breaking change in git 2.16.0

### DIFF
--- a/src/TQ/Git/Repository/Repository.php
+++ b/src/TQ/Git/Repository/Repository.php
@@ -1048,4 +1048,24 @@ class Repository extends AbstractRepository
 
         return $retVar;
     }
+
+    /**
+     * Translates the application's path representation to a valid git pathspec
+     *
+     * @link https://git-scm.com/docs/gitglossary#gitglossary-aiddefpathspecapathspec
+     *
+     * @param string $path
+     * @return string
+     */
+    protected function translatePathspec($path)
+    {
+        // An empty string in this application's context means the current working directory.
+        // Due to breaking changes in git 2.16.0 (see https://github.com/git/git/blob/master/Documentation/RelNotes/2.16.0.txt)
+        // an empty path is no longer a valid pathspec but a dot
+        if ($path === '') {
+            $path = '.';
+        }
+
+        return $path;
+    }
 }

--- a/src/TQ/Git/Repository/Repository.php
+++ b/src/TQ/Git/Repository/Repository.php
@@ -837,7 +837,6 @@ class Repository extends AbstractRepository
     {
         $directory  = FileSystem::normalizeDirectorySeparator($directory);
         $directory  = $this->resolveLocalPath(rtrim($directory, '/') . '/');
-        $directory  = $this->translatePathspec($directory);
         $path       = $this->getRepositoryPath();
 
         /** @var $result CallResult */
@@ -846,7 +845,7 @@ class Repository extends AbstractRepository
             '--full-name',
             '-z',
             $ref,
-            $directory
+            $this->translatePathspec($directory)
         ));
         $result->assertSuccess(sprintf('Cannot list directory "%s" at "%s" from "%s"',
             $directory, $ref, $this->getRepositoryPath()

--- a/src/TQ/Git/Repository/Repository.php
+++ b/src/TQ/Git/Repository/Repository.php
@@ -262,7 +262,7 @@ class Repository extends AbstractRepository
         }
         if ($file !== null) {
             $args[] = '--';
-            $args   = array_merge($args, $this->resolveLocalPath($file));
+            $args   = array_merge($args, array_map(array($this, 'translatePathspec'), $this->resolveLocalPath($file)));
         } else {
             $args[] = '--all';
         }
@@ -837,6 +837,7 @@ class Repository extends AbstractRepository
     {
         $directory  = FileSystem::normalizeDirectorySeparator($directory);
         $directory  = $this->resolveLocalPath(rtrim($directory, '/') . '/');
+        $directory  = $this->translatePathspec($directory);
         $path       = $this->getRepositoryPath();
 
         /** @var $result CallResult */
@@ -936,7 +937,7 @@ class Repository extends AbstractRepository
                 $args[] = '--staged';
             }
 
-            $args[] = $file;
+            $args[] = $this->translatePathspec($file);
 
             /** @var CallResult $result */
             $result = $this->getGit()->{'diff'}($this->getRepositoryPath(), $args);


### PR DESCRIPTION
Follow up of https://github.com/teqneers/PHP-Stream-Wrapper-for-Git/pull/26

Due to a breaking change in git 2.16.0 (see https://github.com/git/git/blob/master/Documentation/RelNotes/2.16.0.txt) pathspecs can no longer be empty.
Empty previously meant the current working directory and can be replaced by a dot (`.`).

In my previous MR (#26) I've updated the [local path resolving function](https://github.com/teqneers/PHP-Stream-Wrapper-for-Git/blob/master/src/TQ/Vcs/Repository/AbstractRepository.php#L167) to never return an empty string but a dot for the current working dir (https://github.com/teqneers/PHP-Stream-Wrapper-for-Git/pull/26/commits/c56e7ead9aa73cafa737ac6538cea68bb3b6edbc).
This however broke the library because this function is used in multiple functions in the [git repository class](https://github.com/teqneers/PHP-Stream-Wrapper-for-Git/blob/master/src/TQ/Git/Repository/Repository.php#L49) even to build a _git revision (object)_ (see https://git-scm.com/docs/gitrevisions#_specifying_revisions). This does not work with a `.` path (e.g. `HEAD:.`) (https://git-scm.com/docs/gitrevisions#gitrevisions-emltrevgtltpathgtemegemHEADREADMEememREADMEememmasterREADMEem).

Because of this behaviour I decided to touch only the functions/commands which require a pathspec (see list of git commands using a pathspec here: https://git-scm.com/docs/gitglossary#gitglossary-aiddefpathspecapathspec).

Please note that this "pathspec fixing" was only applied to the direct arguments of the git command. Otherwise it might break additional logic inside the function which would have required rewriting the whole function (see https://github.com/teqneers/PHP-Stream-Wrapper-for-Git/commit/d7082e4ca62e988f53ce9737afa3e3845258bd9f). E.g. the [`\TQ\Git\Repository\Repository::listDirectory`](https://github.com/teqneers/PHP-Stream-Wrapper-for-Git/blob/master/src/TQ/Git/Repository/Repository.php#L836) function strips the original directory from the file names at the [end](https://github.com/teqneers/PHP-Stream-Wrapper-for-Git/blob/master/src/TQ/Git/Repository/Repository.php#L856).

---
Besides that, another solution would be to change the return value of the [local path resolving function](https://github.com/teqneers/PHP-Stream-Wrapper-for-Git/blob/master/src/TQ/Vcs/Repository/AbstractRepository.php#L167) to a `./` instead of `.`.
Then, this would work in a _git revision (object)_ (see https://git-scm.com/docs/gitrevisions#_specifying_revisions).

I decided against it because the [local path resolving function](https://github.com/teqneers/PHP-Stream-Wrapper-for-Git/blob/master/src/TQ/Vcs/Repository/AbstractRepository.php#L167) is part of the application's logic and interpreting of paths. A translation for git should be done at the lowest level.

Also it might be used somewhere else.