### PR TITLE
Fix PHP 8.1 deprecation warnings and upgrade PHPUnit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ Temporary Items
 
 # PHPUnit
 phpunit.xml
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ cache:
     - $HOME/.composer/cache/files
 
 php:
-  - 7.0
-  - 7.1
-  - 7.2
+  - 8.0
+  - 8.1
   - nightly
 
 env:

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Git Stream Wrapper for PHP
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/teqneers/PHP-Stream-Wrapper-for-Git/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/teqneers/PHP-Stream-Wrapper-for-Git/?branch=master)
 [![Dependency Status](https://www.versioneye.com/user/projects/55b4babe643533001c000587/badge.svg?style=flat)](https://www.versioneye.com/user/projects/55b4babe643533001c000587)
 
-*Git Stream Wrapper for PHP* is a PHP library that allows PHP code to interact with one or multiple Git repositories from within an application. The library consists of a Git repository abstraction that can be used to programatically access Git repositories and of a stream wrapper that can be hooked into the PHP stream infrastructure to allow the developer to use file and directory access functions directly on files in a Git repository. The library provides means to access status information on a Git repository, such as the log, the current repository status or commit information, as well.
+*Git Stream Wrapper for PHP* is a PHP library that allows PHP code to interact with one or multiple Git repositories from within an application. The library consists of a Git repository abstraction that can be used to programmatically access Git repositories and of a stream wrapper that can be hooked into the PHP stream infrastructure to allow the developer to use file and directory access functions directly on files in a Git repository. The library provides means to access status information on a Git repository, such as the log, the current repository status or commit information, as well.
 
-The *Git Stream Wrapper for PHP* core is a wrapper around the Git command line binary so it is required to have Git installed on the machine running the PHP code. ***Git Stream Wrapper for PHP* does not include a Git protocol abstraction**, it relies on the Git command line binary for all its functionality.
+The *Git Stream Wrapper for PHP* core is a wrapper around the Git command line binary, so it is required to have Git installed on the machine running the PHP code. ***Git Stream Wrapper for PHP* does not include a Git protocol abstraction**, it relies on the Git command line binary for all its functionality.
 
 **The code is currently running stable (see comments on Windows below) and should be API-stable. It's however not feature-complete - so please feel free to request features you require.**
 
@@ -66,7 +66,7 @@ $result = $git->transactional(function(TQ\Vcs\Repository\Transaction $t) {
     $t->setCommitMsg('Don\'t know what to write here');
 
     // if we throw an exception from within the callback the changes are discarded
-    // throw new Exception('No we don\'t want to to these changes');
+    // throw new Exception('No we don\'t want to make these changes');
     // note: the exception will be re-thrown by the repository so you have to catch
     // the exception yourself outside the transactional scope.
 });
@@ -167,7 +167,7 @@ StreamWrapper::unregister();
 Requirements
 ------------
 
-- PHP > 7.0.0
+- PHP >= 8.0.0
 - [Composer](https://getcomposer.org) available to include the dependencies
 - Git installed on the machine running the PHP code
 - SVN installed on the machine running the PHP code if you want to use the SVN component
@@ -181,9 +181,9 @@ Run tests
 4. adjust the `GIT_BINARY`, `SVN_BINARY` and `SVN_ADMIN_BINARY` constants in `phpunit.xml` to the path to your Git binary
 5. run `phpunit` from within the cloned project folder
 
-Please note that the library has been tested on a Mac OS X 10.13 with the bundled PHP 7.1.7 (git version 2.14.3) and on several Ubuntu Linux installations. Due to currently unknown reasons the test run a bit unstable on Windows. All tests should be *green* but during cleanup there may be the possibility that some access restrictions randomly kick in and prevent the cleanup code from removing the test directories.
+Please note that the library has been tested on a Mac OS X 12.6 with the bundled PHP 8.0.27, 8.1.14 and 8.2.1 (git version 2.39.1) and on several Ubuntu Linux installations. Due to currently unknown reasons the test run a bit unstable on Windows. All tests should be *green* but during cleanup there may be the possibility that some access restrictions randomly kick in and prevent the cleanup code from removing the test directories.
 
-The unit test suite is continuously tested with [Travis CI](http://travis-ci.org/) on PHP 7.0, 7.1 and 7.2 and its current status is: [![Build Status](https://secure.travis-ci.org/teqneers/PHP-Stream-Wrapper-for-Git.png)](http://travis-ci.org/teqneers/PHP-Stream-Wrapper-for-Git)
+The unit test suite is continuously tested with [Travis CI](http://travis-ci.org/) on PHP 8.0 and 8.1 and its current status is: [![Build Status](https://secure.travis-ci.org/teqneers/PHP-Stream-Wrapper-for-Git.png)](http://travis-ci.org/teqneers/PHP-Stream-Wrapper-for-Git)
 
 Contribute
 ----------

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0"
+        "php": ">=8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7 >=5.7.11",
+        "phpunit/phpunit": "~9.6",
         "knplabs/gaufrette": "~0.5",
         "symfony/yaml": "~3.4"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,31 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false"
-         bootstrap="tests/bootstrap.php"
->
-    <php>
-        <const name="GIT_BINARY" value="/usr/bin/git"/>
-        <const name="SVN_BINARY" value="/usr/bin/svn"/>
-        <const name="SVN_ADMIN_BINARY" value="/usr/bin/svnadmin"/>
-        <const name="TEST_REPO_PATH" value="false"/>
-    </php>
-    <testsuites>
-        <testsuite name="TEQneers Git Stream Wrapper Test Suite">
-            <directory>./tests/TQ/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./src/TQ/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>./src/TQ/</directory>
+    </include>
+  </coverage>
+  <php>
+    <const name="GIT_BINARY" value="/usr/bin/git"/>
+    <const name="SVN_BINARY" value="/usr/bin/svn"/>
+    <const name="SVN_ADMIN_BINARY" value="/usr/bin/svnadmin"/>
+    <const name="TEST_REPO_PATH" value="false"/>
+  </php>
+  <testsuites>
+    <testsuite name="TEQneers Git Stream Wrapper Test Suite">
+      <directory>./tests/TQ/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/TQ/Git/Repository/Repository.php
+++ b/src/TQ/Git/Repository/Repository.php
@@ -251,8 +251,8 @@ class Repository extends AbstractRepository
     /**
      * Adds one or more files to the staging area
      *
-     * @param   array   $file       The file(s) to be added or NULL to add all new and/or changed files to the staging area
-     * @param   boolean $force
+     * @param   array|null  $file       The file(s) to be added or NULL to add all new and/or changed files to the staging area
+     * @param   boolean     $force
      */
     public function add(array $file = null, $force = false)
     {

--- a/src/TQ/Git/StreamWrapper/PathFactory.php
+++ b/src/TQ/Git/StreamWrapper/PathFactory.php
@@ -58,9 +58,9 @@ class PathFactory extends AbstractPathFactory
     /**
      * Creates a path factory
      *
-     * @param   string              $protocol    The protocol (such as "git")
-     * @param   Binary|string|null  $git         The Git binary
-     * @param   RepositoryRegistry  $map         The repository registry
+     * @param   string                   $protocol    The protocol (such as "git")
+     * @param   Binary|string|null       $git         The Git binary
+     * @param   RepositoryRegistry|null  $map         The repository registry
      */
     public function __construct($protocol, $git = null, RepositoryRegistry $map = null)
     {

--- a/src/TQ/Svn/Repository/Repository.php
+++ b/src/TQ/Svn/Repository/Repository.php
@@ -101,6 +101,10 @@ class Repository extends AbstractRepository
 
         $pathWithSvnDir = FileSystem::bubble($path, $hasSvnDir);
 
+        if (is_null($pathWithSvnDir)) {
+            return null;
+        }
+
         $root       = $pathWithSvnDir;
         $parentDir  = dirname($pathWithSvnDir);
         while ($hasSvnDir($parentDir) && strlen($root) > 1) {
@@ -215,8 +219,8 @@ class Repository extends AbstractRepository
     /**
      * Adds one or more files to the staging area
      *
-     * @param   array   $file       The file(s) to be added or NULL to add all new and/or changed files to the staging area
-     * @param   boolean $force
+     * @param   array|null  $file       The file(s) to be added or NULL to add all new and/or changed files to the staging area
+     * @param   boolean     $force
      */
     public function add(array $file = null, $force = false)
     {
@@ -670,22 +674,23 @@ class Repository extends AbstractRepository
     }
 
     /**
-     * Returns the diff of a file
+     * Returns the diff of a files
      *
-     * @param   array  $files       The path to the file
+     * @param   array|null  $files       The path to the files
      * @return  string[]
      */
     public function getDiff(array $files = null)
     {
-        $diffs  = array();
+        $diffs = array();
 
         if (is_null($files)) {
             $status = $this->getStatus();
 
+            $files = [];
             foreach ($status as $entry) {
                 if ($entry['status'] !== 'modified') {
-			continue;
-		}
+                    continue;
+                }
 
                 $files[] = $entry['file'];
             }

--- a/src/TQ/Svn/StreamWrapper/PathFactory.php
+++ b/src/TQ/Svn/StreamWrapper/PathFactory.php
@@ -58,9 +58,9 @@ class PathFactory extends AbstractPathFactory
     /**
      * Creates a path factory
      *
-     * @param   string              $protocol    The protocol (such as "svn")
-     * @param   Binary|string|null  $svn         The SVN binary
-     * @param   RepositoryRegistry  $map         The repository registry
+     * @param   string                   $protocol    The protocol (such as "svn")
+     * @param   Binary|string|null       $svn         The SVN binary
+     * @param   RepositoryRegistry|null  $map         The repository registry
      */
     public function __construct($protocol, $svn = null, RepositoryRegistry $map = null)
     {

--- a/src/TQ/Vcs/Buffer/ArrayBuffer.php
+++ b/src/TQ/Vcs/Buffer/ArrayBuffer.php
@@ -67,7 +67,7 @@ class ArrayBuffer implements \Iterator
      * @link    http://php.net/manual/en/iterator.current.php
      * @return  string
      */
-    public function current()
+    public function current(): mixed
     {
         return current($this->array);
     }
@@ -77,7 +77,7 @@ class ArrayBuffer implements \Iterator
      *
      * @link    http://php.net/manual/en/iterator.next.php
      */
-    public function next()
+    public function next(): void
     {
         next($this->array);
     }
@@ -88,7 +88,7 @@ class ArrayBuffer implements \Iterator
      * @link    http://php.net/manual/en/iterator.key.php
      * @return  integer|boolean     False on failure
      */
-    public function key()
+    public function key(): mixed
     {
         return key($this->array);
     }
@@ -99,7 +99,7 @@ class ArrayBuffer implements \Iterator
      * @link    http://php.net/manual/en/iterator.valid.php
      * @return  boolean
      */
-    public function valid()
+    public function valid(): bool
     {
         return (key($this->array) !== null);
     }
@@ -109,7 +109,7 @@ class ArrayBuffer implements \Iterator
      *
      * @link    http://php.net/manual/en/iterator.rewind.php
      */
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->array);
     }

--- a/src/TQ/Vcs/Repository/AbstractRepository.php
+++ b/src/TQ/Vcs/Repository/AbstractRepository.php
@@ -209,7 +209,7 @@ abstract class AbstractRepository implements RepositoryInterface
      * Runs $function in a transactional scope committing all changes to the repository on success,
      * but rolling back all changes in the event of an Exception being thrown in the closure
      *
-     * The closure $function will be called with a {@see TQ\Vcs\Repository\Transaction} as its only argument
+     * The closure $function will be called with a {@see \TQ\Vcs\Repository\Transaction} as its only argument
      *
      * @param   \Closure   $function        The callback used inside the transaction
      * @return  Transaction

--- a/src/TQ/Vcs/Repository/RepositoryInterface.php
+++ b/src/TQ/Vcs/Repository/RepositoryInterface.php
@@ -91,8 +91,8 @@ interface RepositoryInterface
     /**
      * Adds one or more files to the staging area
      *
-     * @param   array   $file       The file(s) to be added or NULL to add all new and/or changed files to the staging area
-     * @param   boolean $force
+     * @param   array|null  $file       The file(s) to be added or NULL to add all new and/or changed files to the staging area
+     * @param   boolean     $force
      */
     public function add(array $file = null, $force = false);
 
@@ -204,10 +204,10 @@ interface RepositoryInterface
     /**
      * Returns the diff of a file
      *
-     * @param   array  $file       The path to the file
+     * @param   array  $files       The path to the file(s)
      * @return  string[]
      */
-    public function getDiff(array $file);
+    public function getDiff(array $files);
 
     /**
      * Returns true if there are uncommitted changes in the working directory and/or the staging area

--- a/src/TQ/Vcs/StreamWrapper/AbstractPathFactory.php
+++ b/src/TQ/Vcs/StreamWrapper/AbstractPathFactory.php
@@ -61,8 +61,8 @@ abstract class AbstractPathFactory implements PathFactoryInterface
     /**
      * Creates a path factory
      *
-     * @param   string              $protocol    The protocol (such as "vcs")
-     * @param   RepositoryRegistry  $map         The repository registry
+     * @param   string                   $protocol    The protocol (such as "vcs")
+     * @param   RepositoryRegistry|null  $map         The repository registry
      */
     public function __construct($protocol, RepositoryRegistry $map = null)
     {

--- a/src/TQ/Vcs/StreamWrapper/AbstractStreamWrapper.php
+++ b/src/TQ/Vcs/StreamWrapper/AbstractStreamWrapper.php
@@ -727,7 +727,7 @@ abstract class AbstractStreamWrapper
      *                              STREAM_URL_STAT_QUIET   If this flag is set, your wrapper should not raise any errors. If this
      *                                                      flag is not set, you are responsible for reporting errors using the
      *                                                      trigger_error() function during stating of the path.
-     * @return  array           Should return as many elements as stat() does. Unknown or unavailable values should be set to a
+     * @return  array|false     Should return as many elements as stat() does. Unknown or unavailable values should be set to a
      *                          rational value (usually 0).
      */
     public function url_stat($path, $flags)

--- a/src/TQ/Vcs/StreamWrapper/RepositoryRegistry.php
+++ b/src/TQ/Vcs/StreamWrapper/RepositoryRegistry.php
@@ -127,7 +127,7 @@ class RepositoryRegistry implements \Countable
      * @link    http://php.net/manual/en/countable.count.php
      * @return  integer     The custom count as an integer
      */
-    public function count()
+    public function count(): int
     {
         return count($this->map);
     }

--- a/tests/TQ/Tests/Git/Cli/CallCreationTest.php
+++ b/tests/TQ/Tests/Git/Cli/CallCreationTest.php
@@ -23,12 +23,13 @@
 
 namespace TQ\Tests\Git\Cli;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Git\Cli\Binary;
 use TQ\Tests\Helper;
 
-class CallCreationTest extends \PHPUnit_Framework_TestCase
+class CallCreationTest extends TestCase
 {
-    protected function assertCliCommandEquals($expected, $actual)
+    protected function assertCliCommandEquals($expected, $actual): void
     {
         if (strpos(PHP_OS, 'WIN') !== false) {
             $expected = Helper::normalizeEscapeShellArg($expected);
@@ -122,4 +123,3 @@ class CallCreationTest extends \PHPUnit_Framework_TestCase
         $this->assertCliCommandEquals("/usr/bin/git 'command' 'option' '/path/to/file' -- 'path/to/file'", $call->getCmd());
     }
 }
-

--- a/tests/TQ/Tests/Git/Cli/CallResultTest.php
+++ b/tests/TQ/Tests/Git/Cli/CallResultTest.php
@@ -23,9 +23,10 @@
 
 namespace TQ\Tests\Git\Cli;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Git\Cli\Binary;
 
-class CallResultTest extends \PHPUnit_Framework_TestCase
+class CallResultTest extends TestCase
 {
     public function testSuccessfulCall()
     {
@@ -56,4 +57,3 @@ class CallResultTest extends \PHPUnit_Framework_TestCase
         $this->assertGreaterThan(0, $result->getReturnCode());
     }
 }
-

--- a/tests/TQ/Tests/Git/Repository/InfoTest.php
+++ b/tests/TQ/Tests/Git/Repository/InfoTest.php
@@ -23,17 +23,18 @@
 
 namespace TQ\Tests\Git\Repository;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Git\Cli\Binary;
 use TQ\Git\Repository\Repository;
 use TQ\Tests\Helper;
 
-class InfoTest extends \PHPUnit_Framework_TestCase
+class InfoTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
@@ -61,7 +62,7 @@ class InfoTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
     }
@@ -70,7 +71,7 @@ class InfoTest extends \PHPUnit_Framework_TestCase
      *
      * @return  Repository
      */
-    protected function getRepository()
+    protected function getRepository(): Repository
     {
         return Repository::open(TESTS_REPO_PATH_1, new Binary(GIT_BINARY));
     }
@@ -121,63 +122,63 @@ class InfoTest extends \PHPUnit_Framework_TestCase
     {
         $c      = $this->getRepository();
         $log    = $c->getLog();
-        $this->assertEquals(1, count($log));
-        $this->assertContains('Initial commit', $log[0]);
+        $this->assertCount(1, $log);
+        $this->assertStringContainsString('Initial commit', $log[0]);
 
         $hash   = $c->writeFile('/directory/test.txt', 'Test');
         $log    = $c->getLog();
-        $this->assertEquals(2, count($log));
-        $this->assertContains($hash, $log[0]);
-        $this->assertContains('Initial commit', $log[1]);
+        $this->assertCount(2, $log);
+        $this->assertStringContainsString($hash, $log[0]);
+        $this->assertStringContainsString('Initial commit', $log[1]);
 
         $log    = $c->getLog(1);
-        $this->assertEquals(1, count($log));
-        $this->assertContains($hash, $log[0]);
+        $this->assertCount(1, $log);
+        $this->assertStringContainsString($hash, $log[0]);
 
         $log    = $c->getLog(array('limit' => 1));
-        $this->assertEquals(1, count($log));
-        $this->assertContains($hash, $log[0]);
+        $this->assertCount(1, $log);
+        $this->assertStringContainsString($hash, $log[0]);
 
         $log    = $c->getLog(1, 1);
-        $this->assertEquals(1, count($log));
-        $this->assertContains('Initial commit', $log[0]);
+        $this->assertCount(1, $log);
+        $this->assertStringContainsString('Initial commit', $log[0]);
 
         $log    = $c->getLog(array('limit' => 1, 'skip' => 1));
-        $this->assertEquals(1, count($log));
-        $this->assertContains('Initial commit', $log[0]);
+        $this->assertCount(1, $log);
+        $this->assertStringContainsString('Initial commit', $log[0]);
 
         $log    = $c->getLog(10,0);
-        $this->assertEquals(2, count($log));
-        $this->assertContains('Initial commit', $log[1]);
+        $this->assertCount(2, $log);
+        $this->assertStringContainsString('Initial commit', $log[1]);
 
         $log    = $c->getLog(array('limit' => 10, 'skip' => 0));
-        $this->assertEquals(2, count($log));
-        $this->assertContains('Initial commit', $log[1]);
+        $this->assertCount(2, $log);
+        $this->assertStringContainsString('Initial commit', $log[1]);
 
         $log    = $c->getLog(null, null);
-        $this->assertEquals(2, count($log));
-        $this->assertContains('Initial commit', $log[1]);
+        $this->assertCount(2, $log);
+        $this->assertStringContainsString('Initial commit', $log[1]);
 
         $hash2 = $c->writeFile('file7.txt', 'Test create file 7', 'Test create file 7');
         $hash3 = $c->writeFile('file8.txt', 'Test create file 8', 'Test create file 8');
 
         $log    = $c->getLog(array('color', '--', 'file_0.txt'));
         $allLogs = implode("\n", $log);
-        $this->assertEquals(1, count($log));
+        $this->assertCount(1, $log);
         $this->assertEquals(1, substr_count($allLogs, 'create mode'));
-        $this->assertContains('Initial commit', $log[0]);
+        $this->assertStringContainsString('Initial commit', $log[0]);
 
         $log    = $c->getLog(array('--', 'file7.txt'));
         $allLogs = implode("\n", $log);
-        $this->assertEquals(1, count($log));
+        $this->assertCount(1, $log);
         $this->assertEquals(1, substr_count($allLogs, 'create mode'));
-        $this->assertContains('Test create file 7', $log[0]);
+        $this->assertStringContainsString('Test create file 7', $log[0]);
 
         $log    = $c->getLog(array('--', 'file8.txt'));
         $allLogs = implode("\n", $log);
-        $this->assertEquals(1, count($log));
+        $this->assertCount(1, $log);
         $this->assertEquals(1, substr_count($allLogs, 'create mode'));
-        $this->assertContains('Test create file 8', $log[0]);
+        $this->assertStringContainsString('Test create file 8', $log[0]);
 
         $log = $c->getLog(array(
             'limit' => 3,
@@ -188,11 +189,11 @@ class InfoTest extends \PHPUnit_Framework_TestCase
             'date' => 'relative'
         ));
 
-        $this->assertEquals(3, count($log));
-        $this->assertContains(substr($hash3, 0, 7) . ' - ', $log[0]);
-        $this->assertContains('Test create file 8', $log[0]);
-        $this->assertContains(substr($hash2, 0, 7) . ' - Test create file 7', $log[1]);
-        $this->assertContains(substr($hash, 0, 7) . ' - TQ\Git\Repository\Repository created or changed file "/directory/test.txt"', $log[2]);
+        $this->assertCount(3, $log);
+        $this->assertStringContainsString(substr($hash3, 0, 7) . ' - ', $log[0]);
+        $this->assertStringContainsString('Test create file 8', $log[0]);
+        $this->assertStringContainsString(substr($hash2, 0, 7) . ' - Test create file 7', $log[1]);
+        $this->assertStringContainsString(substr($hash, 0, 7) . ' - TQ\Git\Repository\Repository created or changed file "/directory/test.txt"', $log[2]);
 
         $log = $c->getLog(array(
             'pretty' => 'format:"%C(yellow)%h%Cred%d %Creset%s%Cblue [%cn]%Creset"',
@@ -206,8 +207,8 @@ class InfoTest extends \PHPUnit_Framework_TestCase
         $c      = $this->getRepository();
         $hash   = $c->writeFile('test.txt', 'Test');
         $commit = $c->showCommit($hash);
-        $this->assertContains('test.txt', $commit);
-        $this->assertContains('Test', $commit);
+        $this->assertStringContainsString('test.txt', $commit);
+        $this->assertStringContainsString('Test', $commit);
     }
 
     public function testListDirectory()
@@ -307,21 +308,20 @@ class InfoTest extends \PHPUnit_Framework_TestCase
 
         $diff = $c->getDiff(array($file1), true);
         $this->assertEquals(array('file_1.txt'), array_keys($diff));
-        $this->assertRegExp("/\\+Staged1$/", $diff['file_1.txt']);
+        $this->assertMatchesRegularExpression("/\\+Staged1$/", $diff['file_1.txt']);
 
         $diff = $c->getDiff(array($file1), false);
         $this->assertEquals(array('file_1.txt'), array_keys($diff));
-        $this->assertRegExp("/ Staged1\\n\\+Unstaged1$/", $diff['file_1.txt']);
+        $this->assertMatchesRegularExpression("/ Staged1\\n\\+Unstaged1$/", $diff['file_1.txt']);
 
         $diff = $c->getDiff(null, true);
         $this->assertEquals(array('file_1.txt', 'file_2.txt'), array_keys($diff));
-        $this->assertRegExp("/\\+Staged1$/", $diff['file_1.txt']);
-        $this->assertRegExp("/\\+Staged2$/", $diff['file_2.txt']);
+        $this->assertMatchesRegularExpression("/\\+Staged1$/", $diff['file_1.txt']);
+        $this->assertMatchesRegularExpression("/\\+Staged2$/", $diff['file_2.txt']);
 
         $diff = $c->getDiff(null, false);
         $this->assertEquals(array('file_1.txt', 'file_2.txt'), array_keys($diff));
-        $this->assertRegExp("/ Staged1\\n\\+Unstaged1$/", $diff['file_1.txt']);
-        $this->assertRegExp("/ Staged2\\n\\+Unstaged2$/", $diff['file_2.txt']);
+        $this->assertMatchesRegularExpression("/ Staged1\\n\\+Unstaged1$/", $diff['file_1.txt']);
+        $this->assertMatchesRegularExpression("/ Staged2\\n\\+Unstaged2$/", $diff['file_2.txt']);
     }
 }
-

--- a/tests/TQ/Tests/Git/Repository/ModificationTest.php
+++ b/tests/TQ/Tests/Git/Repository/ModificationTest.php
@@ -23,18 +23,19 @@
 
 namespace TQ\Tests\Git\Repository;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Git\Cli\Binary;
 use TQ\Git\Repository\Repository;
 use TQ\Vcs\Repository\Transaction;
 use TQ\Tests\Helper;
 
-class ModificationTest extends \PHPUnit_Framework_TestCase
+class ModificationTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
@@ -61,7 +62,7 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
     }
@@ -70,7 +71,7 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
      *
      * @return  Repository
      */
-    protected function getRepository()
+    protected function getRepository(): Repository
     {
         return Repository::open(TESTS_REPO_PATH_1, new Binary(GIT_BINARY));
     }
@@ -85,7 +86,7 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Test', file_get_contents(TESTS_REPO_PATH_1.'/test.txt'));
 
         $commit = $c->showCommit($hash);
-        $this->assertContains('+++ b/test.txt', $commit);
+        $this->assertStringContainsString('+++ b/test.txt', $commit);
     }
 
     public function testAddFileInSubdirectory()
@@ -98,7 +99,7 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Test', file_get_contents(TESTS_REPO_PATH_1.'/directory/test.txt'));
 
         $commit = $c->showCommit($hash);
-        $this->assertContains('+++ b/directory/test.txt', $commit);
+        $this->assertStringContainsString('+++ b/directory/test.txt', $commit);
     }
 
     public function testAddMultipleFiles()
@@ -108,7 +109,7 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
             $hash   = $c->writeFile(sprintf('test_%s.txt', $i), $i);
             $this->assertEquals(40, strlen($hash));
             $commit = $c->showCommit($hash);
-            $this->assertContains(sprintf('+++ b/test_%d.txt', $i), $commit);
+            $this->assertStringContainsString(sprintf('+++ b/test_%d.txt', $i), $commit);
         }
 
         for ($i = 0; $i < 5; $i++) {
@@ -123,10 +124,10 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $hash   = $c->removeFile('file_0.txt');
         $this->assertEquals(40, strlen($hash));
 
-        $this->assertFileNotExists(TESTS_REPO_PATH_1.'/file_0.txt');
+        $this->assertFileDoesNotExist(TESTS_REPO_PATH_1.'/file_0.txt');
 
         $commit = $c->showCommit($hash);
-        $this->assertContains('--- a/file_0.txt', $commit);
+        $this->assertStringContainsString('--- a/file_0.txt', $commit);
     }
 
     public function testRemoveMultipleFiles()
@@ -136,11 +137,11 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
             $hash   = $c->removeFile(sprintf('file_%s.txt', $i), $i);
             $this->assertEquals(40, strlen($hash));
             $commit = $c->showCommit($hash);
-            $this->assertContains(sprintf('--- a/file_%d.txt', $i), $commit);
+            $this->assertStringContainsString(sprintf('--- a/file_%d.txt', $i), $commit);
         }
 
         for ($i = 0; $i < 5; $i++) {
-            $this->assertFileNotExists(TESTS_REPO_PATH_1.sprintf('/file_%d.txt', $i));
+            $this->assertFileDoesNotExist(TESTS_REPO_PATH_1.sprintf('/file_%d.txt', $i));
         }
     }
 
@@ -151,15 +152,15 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(40, strlen($hash));
 
         for ($i = 0; $i < 5; $i++) {
-            $this->assertFileNotExists(TESTS_REPO_PATH_1.sprintf('/file_%d.txt', $i));
+            $this->assertFileDoesNotExist(TESTS_REPO_PATH_1.sprintf('/file_%d.txt', $i));
         }
 
         $commit = $c->showCommit($hash);
-        $this->assertContains('--- a/file_0.txt', $commit);
-        $this->assertContains('--- a/file_1.txt', $commit);
-        $this->assertContains('--- a/file_2.txt', $commit);
-        $this->assertContains('--- a/file_3.txt', $commit);
-        $this->assertContains('--- a/file_4.txt', $commit);
+        $this->assertStringContainsString('--- a/file_0.txt', $commit);
+        $this->assertStringContainsString('--- a/file_1.txt', $commit);
+        $this->assertStringContainsString('--- a/file_2.txt', $commit);
+        $this->assertStringContainsString('--- a/file_3.txt', $commit);
+        $this->assertStringContainsString('--- a/file_4.txt', $commit);
     }
 
     public function testRemoveSubdirectory()
@@ -170,10 +171,10 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $hash   = $c->removeFile('subdirectory', null, true);
         $this->assertEquals(40, strlen($hash));
 
-        $this->assertFileNotExists(TESTS_REPO_PATH_1.'/subdirectory');
+        $this->assertFileDoesNotExist(TESTS_REPO_PATH_1.'/subdirectory');
 
         $commit = $c->showCommit($hash);
-        $this->assertContains('deleted file', $commit);
+        $this->assertStringContainsString('deleted file', $commit);
     }
 
     public function testMoveFile()
@@ -182,12 +183,12 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $hash   = $c->renameFile('file_0.txt', 'test.txt');
         $this->assertEquals(40, strlen($hash));
 
-        $this->assertFileNotExists(TESTS_REPO_PATH_1.'/file_0.txt');
+        $this->assertFileDoesNotExist(TESTS_REPO_PATH_1.'/file_0.txt');
         $this->assertFileExists(TESTS_REPO_PATH_1.'/test.txt');
 
         $commit = $c->showCommit($hash);
-        $this->assertContains('file_0.txt', $commit);
-        $this->assertContains('test.txt', $commit);
+        $this->assertStringContainsString('file_0.txt', $commit);
+        $this->assertStringContainsString('test.txt', $commit);
     }
 
     public function testReset()
@@ -200,19 +201,19 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($c->isDirty());
         $c->reset();
         $this->assertFalse($c->isDirty());
-        $this->assertFileNotExists($file);
+        $this->assertFileDoesNotExist($file);
 
         file_put_contents($file, 'Test');
         $c->add(array('test.txt'));
         $c->reset();
         $this->assertFalse($c->isDirty());
-        $this->assertFileNotExists($file);
+        $this->assertFileDoesNotExist($file);
 
         file_put_contents($file, 'Test');
         $this->assertTrue($c->isDirty());
         $c->reset(Repository::RESET_WORKING);
         $this->assertFalse($c->isDirty());
-        $this->assertFileNotExists($file);
+        $this->assertFileDoesNotExist($file);
 
         file_put_contents($file, 'Test');
         $c->add(array('test.txt'));
@@ -222,7 +223,7 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $this->assertFileExists($file);
         $c->reset(Repository::RESET_STAGED);
         $this->assertFalse($c->isDirty());
-        $this->assertFileNotExists($file);
+        $this->assertFileDoesNotExist($file);
     }
 
     public function testTransactionalChangesNoException()
@@ -255,18 +256,17 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('test_4.txt', $list);
 
         $commit = $c->showCommit($result->getCommitHash());
-        $this->assertContains($result->getCommitMsg(), $commit);
-        $this->assertContains('+++ b/test_0.txt', $commit);
-        $this->assertContains('+++ b/test_1.txt', $commit);
-        $this->assertContains('+++ b/test_2.txt', $commit);
-        $this->assertContains('+++ b/test_3.txt', $commit);
-        $this->assertContains('+++ b/test_4.txt', $commit);
+        $this->assertStringContainsString($result->getCommitMsg(), $commit);
+        $this->assertStringContainsString('+++ b/test_0.txt', $commit);
+        $this->assertStringContainsString('+++ b/test_1.txt', $commit);
+        $this->assertStringContainsString('+++ b/test_2.txt', $commit);
+        $this->assertStringContainsString('+++ b/test_3.txt', $commit);
+        $this->assertStringContainsString('+++ b/test_4.txt', $commit);
     }
 
     public function testTransactionalChangesException()
     {
         $c  = $this->getRepository();
-
 
         try {
             $c->transactional(function(Transaction $t) {
@@ -307,10 +307,10 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('file_4.txt', $list);
 
         $commit = $c->showCommit($result->getCommitHash());
-        $this->assertContains($result->getCommitMsg(), $commit);
-        $this->assertContains('--- a/file_0.txt', $commit);
-        $this->assertContains('file_1.txt', $commit);
-        $this->assertContains('test.txt', $commit);
+        $this->assertStringContainsString($result->getCommitMsg(), $commit);
+        $this->assertStringContainsString('--- a/file_0.txt', $commit);
+        $this->assertStringContainsString('file_1.txt', $commit);
+        $this->assertStringContainsString('test.txt', $commit);
     }
 
     public function testTransactionalNoChanges()
@@ -328,4 +328,3 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($currentCommit, $c->getCurrentCommit());
     }
 }
-

--- a/tests/TQ/Tests/Git/Repository/SetupTest.php
+++ b/tests/TQ/Tests/Git/Repository/SetupTest.php
@@ -23,17 +23,18 @@
 
 namespace TQ\Tests\Git\Repository;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Git\Cli\Binary;
 use TQ\Git\Repository\Repository;
 use TQ\Tests\Helper;
 
-class SetupTest extends \PHPUnit_Framework_TestCase
+class SetupTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
@@ -49,7 +50,7 @@ class SetupTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
     }
@@ -59,16 +60,14 @@ class SetupTest extends \PHPUnit_Framework_TestCase
      * @param   boolean|integer $create
      * @return  Repository
      */
-    protected function getRepository($path, $create = false)
+    protected function getRepository($path, $create = false): Repository
     {
         return Repository::open($path, new Binary(GIT_BINARY), $create);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRepositoryOpenOnNonExistentPath()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->getRepository('/does/not/exist', false);
     }
 
@@ -79,11 +78,9 @@ class SetupTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(PROJECT_PATH, $c->getRepositoryPath());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRepositoryOpenOnNonRepositoryPath()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->getRepository(TESTS_REPO_PATH_2, false);
     }
 
@@ -118,4 +115,3 @@ class SetupTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('TQ\Git\Repository\Repository', $c);
     }
 }
-

--- a/tests/TQ/Tests/Git/StreamWrapper/DirectoryTest.php
+++ b/tests/TQ/Tests/Git/StreamWrapper/DirectoryTest.php
@@ -23,18 +23,19 @@
 
 namespace TQ\Tests\Git\StreamWrapper;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Git\Cli\Binary;
 use TQ\Git\Repository\Repository;
 use TQ\Git\StreamWrapper\StreamWrapper;
 use TQ\Tests\Helper;
 
-class DirectoryTest extends \PHPUnit_Framework_TestCase
+class DirectoryTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
@@ -74,7 +75,7 @@ class DirectoryTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
 
@@ -85,7 +86,7 @@ class DirectoryTest extends \PHPUnit_Framework_TestCase
      *
      * @return  Repository
      */
-    protected function getRepository()
+    protected function getRepository(): Repository
     {
         return Repository::open(TESTS_REPO_PATH_1, new Binary(GIT_BINARY));
     }
@@ -481,7 +482,7 @@ class DirectoryTest extends \PHPUnit_Framework_TestCase
         $this->assertStringStartsWith('dir', $missingDirectoryName);
 
         $missingDirectoryContents = $c->listDirectory($missingDirectoryName, 'HEAD');
-        $this->assertInternalType('array', $missingDirectoryContents);
+        $this->assertIsArray($missingDirectoryContents);
         $this->assertEquals('file.txt', current($missingDirectoryContents));
 
         $c->removeFile($missingDirectoryName, null, true);
@@ -489,4 +490,3 @@ class DirectoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($c->listDirectory($missingDirectoryName, 'HEAD^'), $missingDirectoryContents);
     }
 }
-

--- a/tests/TQ/Tests/Git/StreamWrapper/FileOperationTest.php
+++ b/tests/TQ/Tests/Git/StreamWrapper/FileOperationTest.php
@@ -23,18 +23,19 @@
 
 namespace TQ\Tests\Git\StreamWrapper;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Git\Cli\Binary;
 use TQ\Git\Repository\Repository;
 use TQ\Git\StreamWrapper\StreamWrapper;
 use TQ\Tests\Helper;
 
-class FileOperationTest extends \PHPUnit_Framework_TestCase
+class FileOperationTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
@@ -64,7 +65,7 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
 
@@ -75,7 +76,7 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
      *
      * @return  Repository
      */
-    protected function getRepository()
+    protected function getRepository(): Repository
     {
         return Repository::open(TESTS_REPO_PATH_1, new Binary(GIT_BINARY));
     }
@@ -85,41 +86,11 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
         $path   = sprintf('git://%s/file_0.txt', TESTS_REPO_PATH_1);
         unlink($path);
 
-        $this->assertFileNotExists(TESTS_REPO_PATH_1.'/file_0.txt');
+        $this->assertFileDoesNotExist(TESTS_REPO_PATH_1.'/file_0.txt');
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertContains('--- a/file_0.txt', $commit);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testUnlinkFileNonHead()
-    {
-        $path   = sprintf('git://%s/file_0.txt#HEAD^', TESTS_REPO_PATH_1);
-        unlink($path);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testUnlinkNonExistantFile()
-    {
-        $path   = sprintf('git://%s/file_does_not_exist.txt', TESTS_REPO_PATH_1);
-        unlink($path);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testUnlinkNonFile()
-    {
-        $c  = $this->getRepository();
-        $c->writeFile('directory/test.txt', 'Test');
-
-        $path   = sprintf('git://%s/directory', TESTS_REPO_PATH_1);
-        unlink($path);
+        $this->assertStringContainsString('--- a/file_0.txt', $commit);
     }
 
     public function testUnlinkFileWithContext()
@@ -135,8 +106,8 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertContains('Hello World', $commit);
-        $this->assertContains('Luke Skywalker <skywalker@deathstar.com>', $commit);
+        $this->assertStringContainsString('Hello World', $commit);
+        $this->assertStringContainsString('Luke Skywalker <skywalker@deathstar.com>', $commit);
     }
 
     public function testRenameFile()
@@ -145,47 +116,14 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
         $pathTo     = sprintf('git://%s/test.txt', TESTS_REPO_PATH_1);
         rename($pathFrom, $pathTo);
 
-        $this->assertFileNotExists(TESTS_REPO_PATH_1.'/file_0.txt');
+        $this->assertFileDoesNotExist(TESTS_REPO_PATH_1.'/file_0.txt');
         $this->assertFileExists(TESTS_REPO_PATH_1.'/test.txt');
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
 
-        $this->assertContains('file_0.txt', $commit);
-        $this->assertContains('test.txt', $commit);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testRenameFileNonHead()
-    {
-        $pathFrom   = sprintf('git://%s/file_0.txt#HEAD^', TESTS_REPO_PATH_1);
-        $pathTo     = sprintf('git://%s/test.txt', TESTS_REPO_PATH_1);
-        rename($pathFrom, $pathTo);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testRenameNonExistantFile()
-    {
-        $pathFrom   = sprintf('git://%s/file_does_not_exist.txt', TESTS_REPO_PATH_1);
-        $pathTo     = sprintf('git://%s/test.txt', TESTS_REPO_PATH_1);
-        rename($pathFrom, $pathTo);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testRenameNonFile()
-    {
-        $c  = $this->getRepository();
-        $c->writeFile('directory/test.txt', 'Test');
-
-        $pathFrom   = sprintf('git://%s/directory', TESTS_REPO_PATH_1);
-        $pathTo     = sprintf('git://%s/test.txt', TESTS_REPO_PATH_1);
-        rename($pathFrom, $pathTo);
+        $this->assertStringContainsString('file_0.txt', $commit);
+        $this->assertStringContainsString('test.txt', $commit);
     }
 
     public function testRenameFileWithContext()
@@ -202,8 +140,8 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertContains('Hello World', $commit);
-        $this->assertContains('Luke Skywalker <skywalker@deathstar.com>', $commit);
+        $this->assertStringContainsString('Hello World', $commit);
+        $this->assertStringContainsString('Luke Skywalker <skywalker@deathstar.com>', $commit);
     }
 
     public function testRmdirDirectory()
@@ -216,42 +154,12 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
         $path   = sprintf('git://%s/directory', TESTS_REPO_PATH_1);
         rmdir($path);
 
-        $this->assertFileNotExists(TESTS_REPO_PATH_1.'/directory');
+        $this->assertFileDoesNotExist(TESTS_REPO_PATH_1.'/directory');
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
 
-        $this->assertContains('--- a/directory/test.txt', $commit);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testRmdirDirectoryNonHead()
-    {
-        $c  = $this->getRepository();
-        $c->writeFile('directory/test.txt', 'Test');
-
-        $path   = sprintf('git://%s/directory#HEAD^', TESTS_REPO_PATH_1);
-        rmdir($path);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testRmdirNonExistantDirectory()
-    {
-        $path   = sprintf('git://%s/directory_does_not_exist', TESTS_REPO_PATH_1);
-        rmdir($path);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testRmdirNonDirectory()
-    {
-        $path   = sprintf('git://%s/file_0.txt', TESTS_REPO_PATH_1);
-        rmdir($path);
+        $this->assertStringContainsString('--- a/directory/test.txt', $commit);
     }
 
     public function testRmdirDirectoryWithContext()
@@ -272,8 +180,8 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertContains('Hello World', $commit);
-        $this->assertContains('Luke Skywalker <skywalker@deathstar.com>', $commit);
+        $this->assertStringContainsString('Hello World', $commit);
+        $this->assertStringContainsString('Luke Skywalker <skywalker@deathstar.com>', $commit);
     }
 
     public function testMkdirDirectory()
@@ -286,28 +194,7 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertContains('b/directory/.gitkeep', $commit);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testMkdirDirectoryNonHead()
-    {
-        $path   = sprintf('git://%s/directory#HEAD^', TESTS_REPO_PATH_1);
-        mkdir($path);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testMkdirExistantDirectory()
-    {
-        $c  = $this->getRepository();
-        $c->writeFile('directory/test.txt', 'Test');
-
-        $path   = sprintf('git://%s/directory', TESTS_REPO_PATH_1);
-        mkdir($path);
+        $this->assertStringContainsString('b/directory/.gitkeep', $commit);
     }
 
     public function testMkdirDirectoryRecursively()
@@ -321,16 +208,7 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertContains('b/directory/directory/.gitkeep', $commit);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testMkdirDirectoryRecursivelyFailsIfNotRequested()
-    {
-        $path   = sprintf('git://%s/directory/directory', TESTS_REPO_PATH_1);
-        mkdir($path, 0777, false);
+        $this->assertStringContainsString('b/directory/directory/.gitkeep', $commit);
     }
 
     public function testMkdirDirectoryWithContext()
@@ -346,8 +224,7 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertContains('Hello World', $commit);
-        $this->assertContains('Luke Skywalker <skywalker@deathstar.com>', $commit);
+        $this->assertStringContainsString('Hello World', $commit);
+        $this->assertStringContainsString('Luke Skywalker <skywalker@deathstar.com>', $commit);
     }
 }
-

--- a/tests/TQ/Tests/Git/StreamWrapper/FileReadTest.php
+++ b/tests/TQ/Tests/Git/StreamWrapper/FileReadTest.php
@@ -23,18 +23,19 @@
 
 namespace TQ\Tests\Git\StreamWrapper;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Git\Cli\Binary;
 use TQ\Git\Repository\Repository;
 use TQ\Git\StreamWrapper\StreamWrapper;
 use TQ\Tests\Helper;
 
-class FileReadTest extends \PHPUnit_Framework_TestCase
+class FileReadTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
@@ -64,7 +65,7 @@ class FileReadTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
 
@@ -75,7 +76,7 @@ class FileReadTest extends \PHPUnit_Framework_TestCase
      *
      * @return  Repository
      */
-    protected function getRepository()
+    protected function getRepository(): Repository
     {
         return Repository::open(TESTS_REPO_PATH_1, new Binary(GIT_BINARY));
     }
@@ -232,4 +233,3 @@ file_4.txt"), Helper::normalizeNewLines(file_get_contents($dir.'#HEAD^^')));
     }
 
 }
-

--- a/tests/TQ/Tests/Git/StreamWrapper/FileWriteTest.php
+++ b/tests/TQ/Tests/Git/StreamWrapper/FileWriteTest.php
@@ -23,18 +23,19 @@
 
 namespace TQ\Tests\Git\StreamWrapper;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Git\Cli\Binary;
 use TQ\Git\Repository\Repository;
 use TQ\Git\StreamWrapper\StreamWrapper;
 use TQ\Tests\Helper;
 
-class FileWriteTest extends \PHPUnit_Framework_TestCase
+class FileWriteTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
@@ -64,7 +65,7 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
 
@@ -75,7 +76,7 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
      *
      * @return  Repository
      */
-    protected function getRepository()
+    protected function getRepository(): Repository
     {
         return Repository::open(TESTS_REPO_PATH_1, new Binary(GIT_BINARY));
     }
@@ -92,8 +93,8 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^\+\+\+ b/test.txt$~m', $commit);
-        $this->assertRegExp('~^\+Test$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\+\+\+ b/test.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\+Test$~m', $commit);
     }
 
     public function testWriteNewFileWithContext()
@@ -114,10 +115,10 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^\+\+\+ b/test.txt$~m', $commit);
-        $this->assertRegExp('~^\+Test$~m', $commit);
-        $this->assertContains('Hello World', $commit);
-        $this->assertContains('Luke Skywalker <skywalker@deathstar.com>', $commit);
+        $this->assertMatchesRegularExpression('~^\+\+\+ b/test.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\+Test$~m', $commit);
+        $this->assertStringContainsString('Hello World', $commit);
+        $this->assertStringContainsString('Luke Skywalker <skywalker@deathstar.com>', $commit);
     }
 
     public function testWriteExistingFile()
@@ -132,10 +133,10 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^--- a/file_0.txt$~m', $commit);
-        $this->assertRegExp('~^\+\+\+ b/file_0.txt$~m', $commit);
-        $this->assertRegExp('~^-File 0$~m', $commit);
-        $this->assertRegExp('~^\+Test$~m', $commit);
+        $this->assertMatchesRegularExpression('~^--- a/file_0.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\+\+\+ b/file_0.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^-File 0$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\+Test$~m', $commit);
     }
 
     public function testAppendExistingFile()
@@ -150,10 +151,10 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^--- a/file_0.txt$~m', $commit);
-        $this->assertRegExp('~^\+\+\+ b/file_0.txt$~m', $commit);
-        $this->assertRegExp('~^-File 0$~m', $commit);
-        $this->assertRegExp('~^\+File 0Test$~m', $commit);
+        $this->assertMatchesRegularExpression('~^--- a/file_0.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\+\+\+ b/file_0.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^-File 0$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\+File 0Test$~m', $commit);
     }
 
     public function testWriteNewFileWithX()
@@ -168,18 +169,8 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^\+\+\+ b/test.txt$~m', $commit);
-        $this->assertRegExp('~^\+Test$~m', $commit);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testWriteExistingFileWithXFails()
-    {
-        $filePath   = sprintf('git://%s/file_0.txt', TESTS_REPO_PATH_1);
-        $file       = fopen($filePath, 'x');
-        fwrite($file, 'Test');
+        $this->assertMatchesRegularExpression('~^\+\+\+ b/test.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\+Test$~m', $commit);
     }
 
     public function testWriteNewFileWithC()
@@ -194,8 +185,8 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^\+\+\+ b/test.txt$~m', $commit);
-        $this->assertRegExp('~^\+Test$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\+\+\+ b/test.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\+Test$~m', $commit);
     }
 
     public function testWriteExistingFileWithC()
@@ -211,10 +202,10 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^--- a/file_0.txt$~m', $commit);
-        $this->assertRegExp('~^\+\+\+ b/file_0.txt$~m', $commit);
-        $this->assertRegExp('~^-File 0$~m', $commit);
-        $this->assertRegExp('~^\+File 0Test$~m', $commit);
+        $this->assertMatchesRegularExpression('~^--- a/file_0.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\+\+\+ b/file_0.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^-File 0$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\+File 0Test$~m', $commit);
     }
 
     public function testWriteAndReadNewFile()
@@ -233,8 +224,8 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^\+\+\+ b/test.txt$~m', $commit);
-        $this->assertRegExp('~^\+Text$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\+\+\+ b/test.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\+Text$~m', $commit);
     }
 
     public function testWriteNewFileWithFilePutContents()
@@ -247,8 +238,8 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^\+\+\+ b/test.txt$~m', $commit);
-        $this->assertRegExp('~^\+Test$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\+\+\+ b/test.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\+Test$~m', $commit);
     }
 
     public function testWriteExistingFileWithFilePutContents()
@@ -261,10 +252,10 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^--- a/file_0.txt$~m', $commit);
-        $this->assertRegExp('~^\+\+\+ b/file_0.txt$~m', $commit);
-        $this->assertRegExp('~^-File 0$~m', $commit);
-        $this->assertRegExp('~^\+Test$~m', $commit);
+        $this->assertMatchesRegularExpression('~^--- a/file_0.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\+\+\+ b/file_0.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^-File 0$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\+Test$~m', $commit);
     }
 
     public function testAppendExistingFileWithFilePutContents()
@@ -277,10 +268,9 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^--- a/file_0.txt$~m', $commit);
-        $this->assertRegExp('~^\+\+\+ b/file_0.txt$~m', $commit);
-        $this->assertRegExp('~^-File 0$~m', $commit);
-        $this->assertRegExp('~^\+File 0Test$~m', $commit);
+        $this->assertMatchesRegularExpression('~^--- a/file_0.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\+\+\+ b/file_0.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^-File 0$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\+File 0Test$~m', $commit);
     }
 }
-

--- a/tests/TQ/Tests/Git/StreamWrapper/RepositorySpecificTest.php
+++ b/tests/TQ/Tests/Git/StreamWrapper/RepositorySpecificTest.php
@@ -23,18 +23,19 @@
 
 namespace TQ\Tests\Git\StreamWrapper;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Git\Cli\Binary;
 use TQ\Git\Repository\Repository;
 use TQ\Git\StreamWrapper\StreamWrapper;
 use TQ\Tests\Helper;
 
-class RepositorySpecificTest extends \PHPUnit_Framework_TestCase
+class RepositorySpecificTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
@@ -75,7 +76,7 @@ class RepositorySpecificTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
 
@@ -151,4 +152,3 @@ class RepositorySpecificTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(5, $i);
     }
 }
-

--- a/tests/TQ/Tests/Git/StreamWrapper/StatusReadTest.php
+++ b/tests/TQ/Tests/Git/StreamWrapper/StatusReadTest.php
@@ -23,18 +23,19 @@
 
 namespace TQ\Tests\Git\StreamWrapper;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Git\Cli\Binary;
 use TQ\Git\Repository\Repository;
 use TQ\Git\StreamWrapper\StreamWrapper;
 use TQ\Tests\Helper;
 
-class StatusReadTest extends \PHPUnit_Framework_TestCase
+class StatusReadTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
@@ -51,7 +52,7 @@ class StatusReadTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
 
@@ -62,7 +63,7 @@ class StatusReadTest extends \PHPUnit_Framework_TestCase
      *
      * @return  Repository
      */
-    protected function getRepository()
+    protected function getRepository(): Repository
     {
         return Repository::open(TESTS_REPO_PATH_1, new Binary(GIT_BINARY));
     }
@@ -80,8 +81,8 @@ class StatusReadTest extends \PHPUnit_Framework_TestCase
             $content    = file_get_contents($commitUrl);
 
             $this->assertStringStartsWith('commit '.$commitHash, $content);
-            $this->assertContains(sprintf('+++ b/test_%d.txt', $c), $content);
-            $this->assertContains(sprintf('+This is file %d', $c), $content);
+            $this->assertStringContainsString(sprintf('+++ b/test_%d.txt', $c), $content);
+            $this->assertStringContainsString(sprintf('+This is file %d', $c), $content);
         }
     }
 
@@ -96,16 +97,16 @@ class StatusReadTest extends \PHPUnit_Framework_TestCase
         $logUrl  = sprintf('git://%s?log', TESTS_REPO_PATH_1);
         $log     = file_get_contents($logUrl);
         foreach ($commits as $commitHash) {
-            $this->assertContains('commit '.$commitHash, $log);
+            $this->assertStringContainsString('commit '.$commitHash, $log);
         }
 
         $logUrl  = sprintf('git://%s?log&limit=%d', TESTS_REPO_PATH_1, 1);
         $log     = file_get_contents($logUrl);
         foreach ($commits as $c => $commitHash) {
             if ($c == count($commits) - 1) {
-                $this->assertContains('commit '.$commitHash, $log);
+                $this->assertStringContainsString('commit '.$commitHash, $log);
             } else {
-                $this->assertNotContains('commit '.$commitHash, $log);
+                $this->assertStringNotContainsString('commit '.$commitHash, $log);
             }
         }
 
@@ -113,9 +114,9 @@ class StatusReadTest extends \PHPUnit_Framework_TestCase
         $log     = file_get_contents($logUrl);
         foreach ($commits as $c => $commitHash) {
             if ($c >= count($commits) - 2) {
-                $this->assertContains('commit '.$commitHash, $log);
+                $this->assertStringContainsString('commit '.$commitHash, $log);
             } else {
-                $this->assertNotContains('commit '.$commitHash, $log);
+                $this->assertStringNotContainsString('commit '.$commitHash, $log);
             }
         }
 
@@ -123,11 +124,10 @@ class StatusReadTest extends \PHPUnit_Framework_TestCase
         $log     = file_get_contents($logUrl);
         foreach ($commits as $c => $commitHash) {
             if (($c >= count($commits) - 3) && ($c < count($commits) - 1)) {
-                $this->assertContains('commit '.$commitHash, $log);
+                $this->assertStringContainsString('commit '.$commitHash, $log);
             } else {
-                $this->assertNotContains('commit '.$commitHash, $log);
+                $this->assertStringNotContainsString('commit '.$commitHash, $log);
             }
         }
     }
 }
-

--- a/tests/TQ/Tests/Helper.php
+++ b/tests/TQ/Tests/Helper.php
@@ -29,7 +29,7 @@ class Helper
      * @param   string  $path
      * @return  boolean
      */
-    public static function createDirectory($path)
+    public static function createDirectory($path): bool
     {
          return mkdir($path, 0777, true);
     }
@@ -38,7 +38,7 @@ class Helper
      * @param   string  $path
      * @throws  \InvalidArgumentException
      */
-    public static function removeDirectory($path)
+    public static function removeDirectory($path): void
     {
         clearstatcache();
         if (!file_exists($path)) {
@@ -80,7 +80,7 @@ class Helper
      * @param   string  $path
      * @return  string
      */
-    public static function normalizeDirectorySeparator($path)
+    public static function normalizeDirectorySeparator($path): string
     {
         return str_replace(array('\\', '/'), '/', $path);
     }
@@ -89,7 +89,7 @@ class Helper
      * @param   string  $string
      * @return  string
      */
-    public static function normalizeNewLines($string)
+    public static function normalizeNewLines($string): string
     {
         return str_replace("\r\n", "\n", $string);
     }
@@ -98,7 +98,7 @@ class Helper
      * @param   string  $command
      * @return  string
      */
-    public static function normalizeEscapeShellArg($command)
+    public static function normalizeEscapeShellArg($command): string
     {
         return str_replace("'", '"', $command);
     }
@@ -107,7 +107,8 @@ class Helper
      * @param   string  $path
      * @return  string
      */
-    public static function initEmptyGitRepository($path) {
+    public static function initEmptyGitRepository($path): string
+    {
          return exec(
              sprintf(
                 'cd %1$s && %2$s init && %2$s config user.email "test@example.com" && %2$s config user.name "test"',
@@ -122,7 +123,7 @@ class Helper
      * @param   string  $command
      * @return  string
      */
-    public static function executeGit($path, $command)
+    public static function executeGit($path, $command): string
     {
         return exec(
             sprintf(
@@ -138,7 +139,8 @@ class Helper
      * @param   string  $path
      * @return  string
      */
-    public static function initEmptySvnRepository($path) {
+    public static function initEmptySvnRepository($path): string
+    {
         $workingDir = $path;
         $repoDir    = dirname($path).'/'.basename($path).'_repo';
 
@@ -169,7 +171,7 @@ class Helper
      * @param   string  $command
      * @return  string
      */
-    public static function executeSvn($path, $command)
+    public static function executeSvn($path, $command): string
     {
         return exec(
             sprintf(

--- a/tests/TQ/Tests/Svn/Cli/CallResultTest.php
+++ b/tests/TQ/Tests/Svn/Cli/CallResultTest.php
@@ -23,9 +23,10 @@
 
 namespace TQ\Tests\Svn\Cli;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Svn\Cli\Binary;
 
-class CallResultTest extends \PHPUnit_Framework_TestCase
+class CallResultTest extends TestCase
 {
     public function testSuccessfulCall()
     {
@@ -56,4 +57,3 @@ class CallResultTest extends \PHPUnit_Framework_TestCase
         $this->assertGreaterThan(0, $result->getReturnCode());
     }
 }
-

--- a/tests/TQ/Tests/Svn/Repository/InfoTest.php
+++ b/tests/TQ/Tests/Svn/Repository/InfoTest.php
@@ -23,17 +23,18 @@
 
 namespace TQ\Tests\Svn\Repository;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Svn\Cli\Binary;
 use TQ\Svn\Repository\Repository;
 use TQ\Tests\Helper;
 
-class InfoTest extends \PHPUnit_Framework_TestCase
+class InfoTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
@@ -60,7 +61,7 @@ class InfoTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
     }
@@ -69,7 +70,7 @@ class InfoTest extends \PHPUnit_Framework_TestCase
      *
      * @return  Repository
      */
-    protected function getRepository()
+    protected function getRepository(): Repository
     {
         return Repository::open(TESTS_REPO_PATH_1, new Binary(SVN_BINARY));
     }
@@ -104,27 +105,27 @@ class InfoTest extends \PHPUnit_Framework_TestCase
     {
         $c      = $this->getRepository();
         $log    = $c->getLog();
-        $this->assertEquals(1, count($log));
-        $this->assertContains('Initial commit', $log[0][3]);
+        $this->assertCount(1, $log);
+        $this->assertStringContainsString('Initial commit', $log[0][3]);
 
         $revision   = $c->writeFile('/directory/test.txt', 'Test');
         $log        = $c->getLog();
 
-        $this->assertEquals(2, count($log));
+        $this->assertCount(2, $log);
         $this->assertEquals($revision, $log[0][0]);
-        $this->assertContains('Initial commit', $log[1][3]);
+        $this->assertStringContainsString('Initial commit', $log[1][3]);
 
         $log    = $c->getLog(1);
-        $this->assertEquals(1, count($log));
+        $this->assertCount(1, $log);
         $this->assertEquals($revision, $log[0][0]);
 
         $log    = $c->getLog(1, 1);
-        $this->assertEquals(1, count($log));
-        $this->assertContains('Initial commit', $log[0][3]);
+        $this->assertCount(1, $log);
+        $this->assertStringContainsString('Initial commit', $log[0][3]);
 
         $log    = $c->getLog(10,0);
-        $this->assertEquals(2, count($log));
-        $this->assertContains('Initial commit', $log[1][3]);
+        $this->assertCount(2, $log);
+        $this->assertStringContainsString('Initial commit', $log[1][3]);
     }
 
     public function testShowCommit()
@@ -132,8 +133,8 @@ class InfoTest extends \PHPUnit_Framework_TestCase
         $c          = $this->getRepository();
         $revision   = $c->writeFile('test.txt', 'Test');
         $commit = $c->showCommit($revision);
-        $this->assertContains('test.txt', $commit);
-        $this->assertContains('TQ\Svn\Repository\Repository created or changed file "test.txt"', $commit);
+        $this->assertStringContainsString('test.txt', $commit);
+        $this->assertStringContainsString('TQ\Svn\Repository\Repository created or changed file "test.txt"', $commit);
     }
 
     public function testListDirectory()
@@ -228,12 +229,11 @@ class InfoTest extends \PHPUnit_Framework_TestCase
 
         $diff = $c->getDiff(array($file1));
         $this->assertEquals(array('file_1.txt'), array_keys($diff));
-        $this->assertRegExp("/\\+Unstaged1$/", $diff['file_1.txt']);
+        $this->assertMatchesRegularExpression("/\\+Unstaged1$/", $diff['file_1.txt']);
 
         $diff = $c->getDiff();
         $this->assertEquals(array('file_1.txt', 'file_2.txt'), array_keys($diff));
-        $this->assertRegExp("/\\+Unstaged1$/", $diff['file_1.txt']);
-        $this->assertRegExp("/\\+Unstaged2$/", $diff['file_2.txt']);
+        $this->assertMatchesRegularExpression("/\\+Unstaged1$/", $diff['file_1.txt']);
+        $this->assertMatchesRegularExpression("/\\+Unstaged2$/", $diff['file_2.txt']);
     }
 }
-

--- a/tests/TQ/Tests/Svn/Repository/ModificationTest.php
+++ b/tests/TQ/Tests/Svn/Repository/ModificationTest.php
@@ -23,18 +23,19 @@
 
 namespace TQ\Tests\Svn\Repository;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Svn\Cli\Binary;
 use TQ\Svn\Repository\Repository;
 use TQ\Tests\Helper;
 use TQ\Vcs\Repository\Transaction;
 
-class ModificationTest extends \PHPUnit_Framework_TestCase
+class ModificationTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
@@ -61,7 +62,7 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
     }
@@ -70,7 +71,7 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
      *
      * @return  Repository
      */
-    protected function getRepository()
+    protected function getRepository(): Repository
     {
         return Repository::open(TESTS_REPO_PATH_1, new Binary(SVN_BINARY));
     }
@@ -85,7 +86,7 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Test', file_get_contents(TESTS_REPO_PATH_1.'/test.txt'));
 
         $commit = $c->showCommit($revision);
-        $this->assertContains('A /test.txt', $commit);
+        $this->assertStringContainsString('A /test.txt', $commit);
     }
 
     public function testAddFileInSubdirectory()
@@ -98,7 +99,7 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Test', file_get_contents(TESTS_REPO_PATH_1.'/directory/test.txt'));
 
         $commit = $c->showCommit($revision);
-        $this->assertContains('A /directory/test.txt', $commit);
+        $this->assertStringContainsString('A /directory/test.txt', $commit);
     }
 
     public function testAddFileInSecondLevelSubdirectory()
@@ -111,7 +112,7 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Test', file_get_contents(TESTS_REPO_PATH_1.'/dirA/dirB/test.txt'));
 
         $commit = $c->showCommit($revision);
-        $this->assertContains('A /dirA/dirB/test.txt', $commit);
+        $this->assertStringContainsString('A /dirA/dirB/test.txt', $commit);
     }
 
     public function testAddMultipleFiles()
@@ -121,7 +122,7 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
             $revision   = $c->writeFile(sprintf('test_%s.txt', $i), $i);
             $this->assertEquals($i + 2, $revision);
             $commit = $c->showCommit($revision);
-            $this->assertContains(sprintf('A /test_%d.txt', $i), $commit);
+            $this->assertStringContainsString(sprintf('A /test_%d.txt', $i), $commit);
         }
 
         for ($i = 0; $i < 5; $i++) {
@@ -136,10 +137,10 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $revision   = $c->removeFile('file_0.txt');
         $this->assertEquals(2, $revision);
 
-        $this->assertFileNotExists(TESTS_REPO_PATH_1.'/file_0.txt');
+        $this->assertFileDoesNotExist(TESTS_REPO_PATH_1.'/file_0.txt');
 
         $commit = $c->showCommit($revision);
-        $this->assertContains('D /file_0.txt', $commit);
+        $this->assertStringContainsString('D /file_0.txt', $commit);
     }
 
     public function testRemoveMultipleFiles()
@@ -149,11 +150,11 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
             $revision   = $c->removeFile(sprintf('file_%s.txt', $i), $i);
             $this->assertEquals($i + 2, $revision);
             $commit = $c->showCommit($revision);
-            $this->assertContains(sprintf('D /file_%d.txt', $i), $commit);
+            $this->assertStringContainsString(sprintf('D /file_%d.txt', $i), $commit);
         }
 
         for ($i = 0; $i < 5; $i++) {
-            $this->assertFileNotExists(TESTS_REPO_PATH_1.sprintf('/file_%d.txt', $i));
+            $this->assertFileDoesNotExist(TESTS_REPO_PATH_1.sprintf('/file_%d.txt', $i));
         }
     }
 
@@ -164,15 +165,15 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, $revision);
 
         for ($i = 0; $i < 5; $i++) {
-            $this->assertFileNotExists(TESTS_REPO_PATH_1.sprintf('/file_%d.txt', $i));
+            $this->assertFileDoesNotExist(TESTS_REPO_PATH_1.sprintf('/file_%d.txt', $i));
         }
 
         $commit = $c->showCommit($revision);
-        $this->assertContains('D /file_0.txt', $commit);
-        $this->assertContains('D /file_1.txt', $commit);
-        $this->assertContains('D /file_2.txt', $commit);
-        $this->assertContains('D /file_3.txt', $commit);
-        $this->assertContains('D /file_4.txt', $commit);
+        $this->assertStringContainsString('D /file_0.txt', $commit);
+        $this->assertStringContainsString('D /file_1.txt', $commit);
+        $this->assertStringContainsString('D /file_2.txt', $commit);
+        $this->assertStringContainsString('D /file_3.txt', $commit);
+        $this->assertStringContainsString('D /file_4.txt', $commit);
     }
 
     public function testRemoveSubdirectory()
@@ -183,10 +184,10 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $revision   = $c->removeFile('subdirectory', null, true);
         $this->assertEquals(3, $revision);
 
-        $this->assertFileNotExists(TESTS_REPO_PATH_1.'/subdirectory');
+        $this->assertFileDoesNotExist(TESTS_REPO_PATH_1.'/subdirectory');
 
         $commit = $c->showCommit($revision);
-        $this->assertContains('deleted file', $commit);
+        $this->assertStringContainsString('deleted file', $commit);
     }
 
     public function testMoveFile()
@@ -195,12 +196,12 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $revision   = $c->renameFile('file_0.txt', 'test.txt');
         $this->assertEquals(2, $revision);
 
-        $this->assertFileNotExists(TESTS_REPO_PATH_1.'/file_0.txt');
+        $this->assertFileDoesNotExist(TESTS_REPO_PATH_1.'/file_0.txt');
         $this->assertFileExists(TESTS_REPO_PATH_1.'/test.txt');
 
         $commit = $c->showCommit($revision);
-        $this->assertContains('A /test.txt', $commit);
-        $this->assertContains('/file_0.txt', $commit);
+        $this->assertStringContainsString('A /test.txt', $commit);
+        $this->assertStringContainsString('/file_0.txt', $commit);
     }
 
     public function testReset()
@@ -213,13 +214,13 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($c->isDirty());
         $c->reset();
         $this->assertFalse($c->isDirty());
-        $this->assertFileNotExists($file);
+        $this->assertFileDoesNotExist($file);
 
         file_put_contents($file, 'Test');
         $c->add(array('test.txt'));
         $c->reset();
         $this->assertFalse($c->isDirty());
-        $this->assertFileNotExists($file);
+        $this->assertFileDoesNotExist($file);
     }
 
     public function testTransactionalChangesNoException()
@@ -252,12 +253,12 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('test_4.txt', $list);
 
         $commit = $c->showCommit($result->getCommitHash());
-        $this->assertContains($result->getCommitMsg(), $commit);
-        $this->assertContains('A /test_0.txt', $commit);
-        $this->assertContains('A /test_1.txt', $commit);
-        $this->assertContains('A /test_2.txt', $commit);
-        $this->assertContains('A /test_3.txt', $commit);
-        $this->assertContains('A /test_4.txt', $commit);
+        $this->assertStringContainsString($result->getCommitMsg(), $commit);
+        $this->assertStringContainsString('A /test_0.txt', $commit);
+        $this->assertStringContainsString('A /test_1.txt', $commit);
+        $this->assertStringContainsString('A /test_2.txt', $commit);
+        $this->assertStringContainsString('A /test_3.txt', $commit);
+        $this->assertStringContainsString('A /test_4.txt', $commit);
     }
 
     public function testTransactionalChangesException()
@@ -304,10 +305,10 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('file_4.txt', $list);
 
         $commit = $c->showCommit($result->getCommitHash());
-        $this->assertContains($result->getCommitMsg(), $commit);
-        $this->assertContains('D /file_0.txt', $commit);
-        $this->assertContains('D /file_1.txt', $commit);
-        $this->assertContains('A /test.txt', $commit);
+        $this->assertStringContainsString($result->getCommitMsg(), $commit);
+        $this->assertStringContainsString('D /file_0.txt', $commit);
+        $this->assertStringContainsString('D /file_1.txt', $commit);
+        $this->assertStringContainsString('A /test.txt', $commit);
     }
 
     public function testTransactionalNoChanges()
@@ -325,4 +326,3 @@ class ModificationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($currentCommit, $c->getCurrentCommit());
     }
 }
-

--- a/tests/TQ/Tests/Svn/Repository/SetupTest.php
+++ b/tests/TQ/Tests/Svn/Repository/SetupTest.php
@@ -23,17 +23,18 @@
 
 namespace TQ\Tests\Svn\Repository;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Svn\Cli\Binary;
 use TQ\Svn\Repository\Repository;
 use TQ\Tests\Helper;
 
-class SetupTest extends \PHPUnit_Framework_TestCase
+class SetupTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
@@ -49,7 +50,7 @@ class SetupTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
     }
@@ -58,24 +59,20 @@ class SetupTest extends \PHPUnit_Framework_TestCase
      * @param   string          $path
      * @return  Repository
      */
-    protected function getRepository($path)
+    protected function getRepository($path): Repository
     {
         return Repository::open($path, new Binary(SVN_BINARY));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRepositoryOpenOnNonExistentPath()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->getRepository('/does/not/exist');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRepositoryOpenOnNonRepositoryPath()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->getRepository(TESTS_REPO_PATH_2);
     }
 
@@ -95,4 +92,3 @@ class SetupTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(TESTS_REPO_PATH_1, $c->getRepositoryPath());
     }
 }
-

--- a/tests/TQ/Tests/Svn/StreamWrapper/DirectoryTest.php
+++ b/tests/TQ/Tests/Svn/StreamWrapper/DirectoryTest.php
@@ -23,18 +23,19 @@
 
 namespace TQ\Tests\Svn\StreamWrapper;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Svn\Cli\Binary;
 use TQ\Svn\Repository\Repository;
 use TQ\Svn\StreamWrapper\StreamWrapper;
 use TQ\Tests\Helper;
 
-class DirectoryTest extends \PHPUnit_Framework_TestCase
+class DirectoryTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
@@ -74,7 +75,7 @@ class DirectoryTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
 
@@ -85,7 +86,7 @@ class DirectoryTest extends \PHPUnit_Framework_TestCase
      *
      * @return  Repository
      */
-    protected function getRepository()
+    protected function getRepository(): Repository
     {
         return Repository::open(TESTS_REPO_PATH_1, new Binary(SVN_BINARY));
     }
@@ -467,4 +468,3 @@ class DirectoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(count($ex), $i);
     }
 }
-

--- a/tests/TQ/Tests/Svn/StreamWrapper/FileOperationTest.php
+++ b/tests/TQ/Tests/Svn/StreamWrapper/FileOperationTest.php
@@ -23,18 +23,19 @@
 
 namespace TQ\Tests\Svn\StreamWrapper;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Svn\Cli\Binary;
 use TQ\Svn\Repository\Repository;
 use TQ\Svn\StreamWrapper\StreamWrapper;
 use TQ\Tests\Helper;
 
-class FileOperationTest extends \PHPUnit_Framework_TestCase
+class FileOperationTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
@@ -63,7 +64,7 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
 
@@ -74,7 +75,7 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
      *
      * @return  Repository
      */
-    protected function getRepository()
+    protected function getRepository(): Repository
     {
         return Repository::open(TESTS_REPO_PATH_1, new Binary(SVN_BINARY));
     }
@@ -84,41 +85,11 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
         $path   = sprintf('svn://%s/file_0.txt', TESTS_REPO_PATH_1);
         unlink($path);
 
-        $this->assertFileNotExists(TESTS_REPO_PATH_1.'/file_0.txt');
+        $this->assertFileDoesNotExist(TESTS_REPO_PATH_1.'/file_0.txt');
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertContains('D /file_0.txt', $commit);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testUnlinkFileNonHead()
-    {
-        $path   = sprintf('svn://%s/file_0.txt#1', TESTS_REPO_PATH_1);
-        unlink($path);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testUnlinkNonExistantFile()
-    {
-        $path   = sprintf('svn://%s/file_does_not_exist.txt', TESTS_REPO_PATH_1);
-        unlink($path);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testUnlinkNonFile()
-    {
-        $c  = $this->getRepository();
-        $c->writeFile('directory/test.txt', 'Test');
-
-        $path   = sprintf('svn://%s/directory', TESTS_REPO_PATH_1);
-        unlink($path);
+        $this->assertStringContainsString('D /file_0.txt', $commit);
     }
 
     public function testUnlinkFileWithContext()
@@ -134,8 +105,8 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertContains('Hello World', $commit);
-        $this->assertContains('Luke Skywalker <skywalker@deathstar.com>', $commit);
+        $this->assertStringContainsString('Hello World', $commit);
+        $this->assertStringContainsString('Luke Skywalker <skywalker@deathstar.com>', $commit);
     }
 
     public function testRenameFile()
@@ -144,46 +115,13 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
         $pathTo     = sprintf('svn://%s/test.txt', TESTS_REPO_PATH_1);
         rename($pathFrom, $pathTo);
 
-        $this->assertFileNotExists(TESTS_REPO_PATH_1.'/file_0.txt');
+        $this->assertFileDoesNotExist(TESTS_REPO_PATH_1.'/file_0.txt');
         $this->assertFileExists(TESTS_REPO_PATH_1.'/test.txt');
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertContains('D /file_0.txt', $commit);
-        $this->assertContains('A /test.txt', $commit);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testRenameFileNonHead()
-    {
-        $pathFrom   = sprintf('svn://%s/file_0.txt#1', TESTS_REPO_PATH_1);
-        $pathTo     = sprintf('svn://%s/test.txt', TESTS_REPO_PATH_1);
-        rename($pathFrom, $pathTo);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testRenameNonExistantFile()
-    {
-        $pathFrom   = sprintf('svn://%s/file_does_not_exist.txt', TESTS_REPO_PATH_1);
-        $pathTo     = sprintf('svn://%s/test.txt', TESTS_REPO_PATH_1);
-        rename($pathFrom, $pathTo);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testRenameNonFile()
-    {
-        $c  = $this->getRepository();
-        $c->writeFile('directory/test.txt', 'Test');
-
-        $pathFrom   = sprintf('svn://%s/directory', TESTS_REPO_PATH_1);
-        $pathTo     = sprintf('svn://%s/test.txt', TESTS_REPO_PATH_1);
-        rename($pathFrom, $pathTo);
+        $this->assertStringContainsString('D /file_0.txt', $commit);
+        $this->assertStringContainsString('A /test.txt', $commit);
     }
 
     public function testRenameFileWithContext()
@@ -200,8 +138,8 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertContains('Hello World', $commit);
-        $this->assertContains('Luke Skywalker <skywalker@deathstar.com>', $commit);
+        $this->assertStringContainsString('Hello World', $commit);
+        $this->assertStringContainsString('Luke Skywalker <skywalker@deathstar.com>', $commit);
     }
 
     public function testRmdirDirectory()
@@ -214,42 +152,12 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
         $path   = sprintf('svn://%s/directory', TESTS_REPO_PATH_1);
         rmdir($path);
 
-        $this->assertFileNotExists(TESTS_REPO_PATH_1.'/directory');
+        $this->assertFileDoesNotExist(TESTS_REPO_PATH_1.'/directory');
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
 
-        $this->assertContains('D /directory', $commit);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testRmdirDirectoryNonHead()
-    {
-        $c  = $this->getRepository();
-        $c->writeFile('directory/test.txt', 'Test');
-
-        $path   = sprintf('svn://%s/directory#1', TESTS_REPO_PATH_1);
-        rmdir($path);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testRmdirNonExistantDirectory()
-    {
-        $path   = sprintf('svn://%s/directory_does_not_exist', TESTS_REPO_PATH_1);
-        rmdir($path);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testRmdirNonDirectory()
-    {
-        $path   = sprintf('svn://%s/file_0.txt', TESTS_REPO_PATH_1);
-        rmdir($path);
+        $this->assertStringContainsString('D /directory', $commit);
     }
 
     public function testRmdirDirectoryWithContext()
@@ -270,8 +178,8 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertContains('Hello World', $commit);
-        $this->assertContains('Luke Skywalker <skywalker@deathstar.com>', $commit);
+        $this->assertStringContainsString('Hello World', $commit);
+        $this->assertStringContainsString('Luke Skywalker <skywalker@deathstar.com>', $commit);
     }
 
     public function testMkdirDirectory()
@@ -283,28 +191,7 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertContains('A /directory', $commit);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testMkdirDirectoryNonHead()
-    {
-        $path   = sprintf('svn://%s/directory#1', TESTS_REPO_PATH_1);
-        mkdir($path);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testMkdirExistantDirectory()
-    {
-        $c  = $this->getRepository();
-        $c->writeFile('directory/test.txt', 'Test');
-
-        $path   = sprintf('svn://%s/directory', TESTS_REPO_PATH_1);
-        mkdir($path);
+        $this->assertStringContainsString('A /directory', $commit);
     }
 
     public function testMkdirDirectoryRecursively()
@@ -317,16 +204,7 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertContains('A /directory/directory', $commit);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testMkdirDirectoryRecursivelyFailsIfNotRequested()
-    {
-        $path   = sprintf('svn://%s/directory/directory', TESTS_REPO_PATH_1);
-        mkdir($path, 0777, false);
+        $this->assertStringContainsString('A /directory/directory', $commit);
     }
 
     public function testMkdirDirectoryWithContext()
@@ -342,8 +220,7 @@ class FileOperationTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertContains('Hello World', $commit);
-        $this->assertContains('Luke Skywalker <skywalker@deathstar.com>', $commit);
+        $this->assertStringContainsString('Hello World', $commit);
+        $this->assertStringContainsString('Luke Skywalker <skywalker@deathstar.com>', $commit);
     }
 }
-

--- a/tests/TQ/Tests/Svn/StreamWrapper/FileReadTest.php
+++ b/tests/TQ/Tests/Svn/StreamWrapper/FileReadTest.php
@@ -23,18 +23,19 @@
 
 namespace TQ\Tests\Svn\StreamWrapper;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Svn\Cli\Binary;
 use TQ\Svn\Repository\Repository;
 use TQ\Svn\StreamWrapper\StreamWrapper;
 use TQ\Tests\Helper;
 
-class FileReadTest extends \PHPUnit_Framework_TestCase
+class FileReadTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
@@ -63,7 +64,7 @@ class FileReadTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
 
@@ -74,7 +75,7 @@ class FileReadTest extends \PHPUnit_Framework_TestCase
      *
      * @return  Repository
      */
-    protected function getRepository()
+    protected function getRepository(): Repository
     {
         return Repository::open(TESTS_REPO_PATH_1, new Binary(SVN_BINARY));
     }
@@ -173,4 +174,3 @@ class FileReadTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Test 1', file_get_contents($file.'#'.$commit1));
     }
 }
-

--- a/tests/TQ/Tests/Svn/StreamWrapper/FileStatTest.php
+++ b/tests/TQ/Tests/Svn/StreamWrapper/FileStatTest.php
@@ -21,68 +21,63 @@
  * THE SOFTWARE.
  */
 
-namespace TQ\Tests\Git\StreamWrapper;
+namespace TQ\Tests\Svn\StreamWrapper;
 
-use TQ\Git\Cli\Binary;
-use TQ\Git\Repository\Repository;
-use TQ\Git\StreamWrapper\StreamWrapper;
+use PHPUnit\Framework\TestCase;
+use TQ\Svn\Cli\Binary;
+use TQ\Svn\Repository\Repository;
+use TQ\Svn\StreamWrapper\StreamWrapper;
 use TQ\Tests\Helper;
 
-class FileStatTest extends \PHPUnit_Framework_TestCase
+class FileStatTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_REPO_PATH_1);
 
-        Helper::initEmptyGitRepository(TESTS_REPO_PATH_1);
+        Helper::initEmptySvnRepository(TESTS_REPO_PATH_1);
 
         $path   = TESTS_REPO_PATH_1.'/test.txt';
         file_put_contents($path, 'File 1');
-        Helper::executeGit(TESTS_REPO_PATH_1, sprintf('add %s',
+        Helper::executeSvn(TESTS_REPO_PATH_1, sprintf('add %s',
             escapeshellarg($path)
         ));
-
-        Helper::executeGit(TESTS_REPO_PATH_1, sprintf('commit --message=%s',
+        Helper::executeSvn(TESTS_REPO_PATH_1, sprintf('commit --message=%s',
             escapeshellarg('Commit 1')
         ));
 
         $path   = TESTS_REPO_PATH_1.'/directory';
         Helper::createDirectory($path);
         file_put_contents($path.'/test.txt', 'Directory File 1');
-        Helper::executeGit(TESTS_REPO_PATH_1, sprintf('add %s',
+        Helper::executeSvn(TESTS_REPO_PATH_1, sprintf('add %s',
             escapeshellarg($path)
         ));
-
-        Helper::executeGit(TESTS_REPO_PATH_1, sprintf('commit --message=%s',
+        Helper::executeSvn(TESTS_REPO_PATH_1, sprintf('commit --message=%s',
             escapeshellarg('Commit 2')
         ));
 
         $path   = TESTS_REPO_PATH_1.'/test.txt';
         file_put_contents($path, 'File 1 New');
-        Helper::executeGit(TESTS_REPO_PATH_1, sprintf('add %s',
-            escapeshellarg($path)
-        ));
-
-        Helper::executeGit(TESTS_REPO_PATH_1, sprintf('commit --message=%s',
+        Helper::executeSvn(TESTS_REPO_PATH_1, sprintf('commit --message=%s',
             escapeshellarg('Commit 3')
         ));
 
         clearstatcache();
 
-        StreamWrapper::register('git', new Binary(GIT_BINARY));
+        StreamWrapper::register('svn', new Binary(SVN_BINARY));
     }
 
     /**
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
 
@@ -93,16 +88,16 @@ class FileStatTest extends \PHPUnit_Framework_TestCase
      *
      * @return  Repository
      */
-    protected function getRepository()
+    protected function getRepository(): Repository
     {
-        return Repository::open(TESTS_REPO_PATH_1, new Binary(GIT_BINARY));
+        return Repository::open(TESTS_REPO_PATH_1, new Binary(SVN_BINARY));
     }
 
     public function testUrlStatFileWorkingDirectory()
     {
-        $filePath   = sprintf('git://%s/test.txt', TESTS_REPO_PATH_1);
+        $filePath   = sprintf('svn://%s/test.txt', TESTS_REPO_PATH_1);
         $stat       = stat($filePath);
-        $this->assertEquals(26, count($stat));
+        $this->assertCount(26, $stat);
         $this->assertEquals(0100000, $stat['mode'] & 0100000);
         $this->assertEquals(10, $stat['size']);
 
@@ -110,28 +105,27 @@ class FileStatTest extends \PHPUnit_Framework_TestCase
 
     public function testUrlStatDirWorkingDirectory()
     {
-        $dirPath    = sprintf('git://%s/directory', TESTS_REPO_PATH_1);
+        $dirPath    = sprintf('svn://%s/directory', TESTS_REPO_PATH_1);
         $stat       = stat($dirPath);
-        $this->assertEquals(26, count($stat));
+        $this->assertCount(26, $stat);
         $this->assertEquals(0040000, $stat['mode'] & 0040000);
     }
 
     public function testUrlStatFileHistory()
     {
-        $filePath   = sprintf('git://%s/test.txt#HEAD^', TESTS_REPO_PATH_1);
+        $filePath   = sprintf('svn://%s/test.txt#2', TESTS_REPO_PATH_1);
         $stat       = stat($filePath);
-        $this->assertEquals(26, count($stat));
+        $this->assertCount(26, $stat);
         $this->assertEquals(0100000, $stat['mode'] & 0100000);
-        $this->assertEquals(6, $stat['size']);
+        $this->assertEquals(0, $stat['size']);
 
     }
 
     public function testUrlStatDirHistory()
     {
-        $dirPath    = sprintf('git://%s/directory#HEAD^', TESTS_REPO_PATH_1);
+        $dirPath    = sprintf('svn://%s/directory#2', TESTS_REPO_PATH_1);
         $stat       = stat($dirPath);
-        $this->assertEquals(26, count($stat));
+        $this->assertCount(26, $stat);
         $this->assertEquals(0040000, $stat['mode'] & 0040000);
     }
 }
-

--- a/tests/TQ/Tests/Svn/StreamWrapper/FileWriteTest.php
+++ b/tests/TQ/Tests/Svn/StreamWrapper/FileWriteTest.php
@@ -23,18 +23,19 @@
 
 namespace TQ\Tests\Svn\StreamWrapper;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Svn\Cli\Binary;
 use TQ\Svn\Repository\Repository;
 use TQ\Svn\StreamWrapper\StreamWrapper;
 use TQ\Tests\Helper;
 
-class FileWriteTest extends \PHPUnit_Framework_TestCase
+class FileWriteTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
@@ -63,7 +64,7 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
 
@@ -74,7 +75,7 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
      *
      * @return  Repository
      */
-    protected function getRepository()
+    protected function getRepository(): Repository
     {
         return Repository::open(TESTS_REPO_PATH_1, new Binary(SVN_BINARY));
     }
@@ -91,7 +92,7 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^\s{3}A /test.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\s{3}A /test.txt$~m', $commit);
     }
 
     public function testWriteNewFileWithContext()
@@ -112,9 +113,9 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^\s{3}A /test.txt$~m', $commit);
-        $this->assertContains('Hello World', $commit);
-        $this->assertContains('Luke Skywalker <skywalker@deathstar.com>', $commit);
+        $this->assertMatchesRegularExpression('~^\s{3}A /test.txt$~m', $commit);
+        $this->assertStringContainsString('Hello World', $commit);
+        $this->assertStringContainsString('Luke Skywalker <skywalker@deathstar.com>', $commit);
     }
 
     public function testWriteExistingFile()
@@ -129,7 +130,7 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^\s{3}M /file_0.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\s{3}M /file_0.txt$~m', $commit);
     }
 
     public function testAppendExistingFile()
@@ -144,7 +145,7 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^\s{3}M /file_0.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\s{3}M /file_0.txt$~m', $commit);
     }
 
     public function testWriteNewFileWithX()
@@ -159,17 +160,7 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^\s{3}A /test.txt$~m', $commit);
-    }
-
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
-    public function testWriteExistingFileWithXFails()
-    {
-        $filePath   = sprintf('svn://%s/file_0.txt', TESTS_REPO_PATH_1);
-        $file       = fopen($filePath, 'x');
-        fwrite($file, 'Test');
+        $this->assertMatchesRegularExpression('~^\s{3}A /test.txt$~m', $commit);
     }
 
     public function testWriteNewFileWithC()
@@ -184,7 +175,7 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^\s{3}A /test.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\s{3}A /test.txt$~m', $commit);
     }
 
     public function testWriteExistingFileWithC()
@@ -200,7 +191,7 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^\s{3}M /file_0.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\s{3}M /file_0.txt$~m', $commit);
     }
 
     public function testWriteAndReadNewFile()
@@ -219,7 +210,7 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^\s{3}A /test.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\s{3}A /test.txt$~m', $commit);
     }
 
     public function testWriteNewFileWithFilePutContents()
@@ -232,7 +223,7 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^\s{3}A /test.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\s{3}A /test.txt$~m', $commit);
     }
 
     public function testWriteExistingFileWithFilePutContents()
@@ -245,7 +236,7 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^\s{3}M /file_0.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\s{3}M /file_0.txt$~m', $commit);
     }
 
     public function testAppendExistingFileWithFilePutContents()
@@ -258,7 +249,6 @@ class FileWriteTest extends \PHPUnit_Framework_TestCase
 
         $c      = $this->getRepository();
         $commit = $c->showCommit($c->getCurrentCommit());
-        $this->assertRegExp('~^\s{3}M /file_0.txt$~m', $commit);
+        $this->assertMatchesRegularExpression('~^\s{3}M /file_0.txt$~m', $commit);
     }
 }
-

--- a/tests/TQ/Tests/Svn/StreamWrapper/RepositorySpecificTest.php
+++ b/tests/TQ/Tests/Svn/StreamWrapper/RepositorySpecificTest.php
@@ -23,18 +23,19 @@
 
 namespace TQ\Tests\Svn\StreamWrapper;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Svn\Cli\Binary;
 use TQ\Svn\Repository\Repository;
 use TQ\Svn\StreamWrapper\StreamWrapper;
 use TQ\Tests\Helper;
 
-class RepositorySpecificTest extends \PHPUnit_Framework_TestCase
+class RepositorySpecificTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
@@ -75,7 +76,7 @@ class RepositorySpecificTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
 
@@ -151,4 +152,3 @@ class RepositorySpecificTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(5, $i);
     }
 }
-

--- a/tests/TQ/Tests/Svn/StreamWrapper/StatusReadTest.php
+++ b/tests/TQ/Tests/Svn/StreamWrapper/StatusReadTest.php
@@ -23,18 +23,19 @@
 
 namespace TQ\Tests\Svn\StreamWrapper;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Svn\Cli\Binary;
 use TQ\Svn\Repository\Repository;
 use TQ\Svn\StreamWrapper\StreamWrapper;
 use TQ\Tests\Helper;
 
-class StatusReadTest extends \PHPUnit_Framework_TestCase
+class StatusReadTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
@@ -51,7 +52,7 @@ class StatusReadTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
 
@@ -62,7 +63,7 @@ class StatusReadTest extends \PHPUnit_Framework_TestCase
      *
      * @return  Repository
      */
-    protected function getRepository()
+    protected function getRepository(): Repository
     {
         return Repository::open(TESTS_REPO_PATH_1, new Binary(SVN_BINARY));
     }
@@ -79,8 +80,8 @@ class StatusReadTest extends \PHPUnit_Framework_TestCase
             $commitUrl  = sprintf('svn://%s?commit&ref=%s', TESTS_REPO_PATH_1, $commitRevision);
             $content    = file_get_contents($commitUrl);
 
-            $this->assertContains('r'.$commitRevision.' |', $content);
-            $this->assertContains(sprintf('A /test_%d.txt', $c), $content);
+            $this->assertStringContainsString('r'.$commitRevision.' |', $content);
+            $this->assertStringContainsString(sprintf('A /test_%d.txt', $c), $content);
         }
     }
 
@@ -95,16 +96,16 @@ class StatusReadTest extends \PHPUnit_Framework_TestCase
         $logUrl  = sprintf('svn://%s?log', TESTS_REPO_PATH_1);
         $log     = file_get_contents($logUrl);
         foreach ($commits as $commitRevision) {
-            $this->assertContains('r'.$commitRevision.' |', $log);
+            $this->assertStringContainsString('r'.$commitRevision.' |', $log);
         }
 
         $logUrl  = sprintf('svn://%s?log&limit=%d', TESTS_REPO_PATH_1, 1);
         $log     = file_get_contents($logUrl);
         foreach ($commits as $c => $commitRevision) {
             if ($c == count($commits) - 1) {
-                $this->assertContains('r'.$commitRevision.' |', $log);
+                $this->assertStringContainsString('r'.$commitRevision.' |', $log);
             } else {
-                $this->assertNotContains('r'.$commitRevision.' |', $log);
+                $this->assertStringNotContainsString('r'.$commitRevision.' |', $log);
             }
         }
 
@@ -112,9 +113,9 @@ class StatusReadTest extends \PHPUnit_Framework_TestCase
         $log     = file_get_contents($logUrl);
         foreach ($commits as $c => $commitRevision) {
             if ($c >= count($commits) - 2) {
-                $this->assertContains('r'.$commitRevision.' |', $log);
+                $this->assertStringContainsString('r'.$commitRevision.' |', $log);
             } else {
-                $this->assertNotContains('r'.$commitRevision.' |', $log);
+                $this->assertStringNotContainsString('r'.$commitRevision.' |', $log);
             }
         }
 
@@ -122,11 +123,10 @@ class StatusReadTest extends \PHPUnit_Framework_TestCase
         $log     = file_get_contents($logUrl);
         foreach ($commits as $c => $commitRevision) {
             if (($c >= count($commits) - 3) && ($c < count($commits) - 1)) {
-                $this->assertContains('r'.$commitRevision.' |', $log);
+                $this->assertStringContainsString('r'.$commitRevision.' |', $log);
             } else {
-                $this->assertNotContains('r'.$commitRevision.' |', $log);
+                $this->assertStringNotContainsString('r'.$commitRevision.' |', $log);
             }
         }
     }
 }
-

--- a/tests/TQ/Tests/Vcs/Buffer/ArrayBufferTest.php
+++ b/tests/TQ/Tests/Vcs/Buffer/ArrayBufferTest.php
@@ -23,9 +23,10 @@
 
 namespace TQ\Tests\Vcs\Buffer;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Vcs\Buffer\ArrayBuffer;
 
-class ArrayBufferTest extends \PHPUnit_Framework_TestCase
+class ArrayBufferTest extends TestCase
 {
     public function testIteration()
     {
@@ -38,7 +39,7 @@ class ArrayBufferTest extends \PHPUnit_Framework_TestCase
             $i++;
             $iterator->next();
         }
-        $this->assertEquals(count($listing), $i);
+        $this->assertCount($i, $listing);
 
         $iterator->rewind();
         $this->assertEquals(reset($listing), $iterator->current());
@@ -58,4 +59,3 @@ class ArrayBufferTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(count($listing), $i);
     }
 }
-

--- a/tests/TQ/Tests/Vcs/Buffer/StreamBufferTest.php
+++ b/tests/TQ/Tests/Vcs/Buffer/StreamBufferTest.php
@@ -23,16 +23,17 @@
 
 namespace TQ\Tests\Vcs\Buffer;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Vcs\Buffer\StreamBuffer;
 use TQ\Tests\Helper;
 
-class StreamBufferTest extends \PHPUnit_Framework_TestCase
+class StreamBufferTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
@@ -48,7 +49,7 @@ class StreamBufferTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
     }
@@ -154,4 +155,3 @@ class StreamBufferTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $actual);
     }
 }
-

--- a/tests/TQ/Tests/Vcs/Buffer/StringBufferTest.php
+++ b/tests/TQ/Tests/Vcs/Buffer/StringBufferTest.php
@@ -23,9 +23,10 @@
 
 namespace TQ\Tests\Vcs\Buffer;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Vcs\Buffer\StringBuffer;
 
-class StringBufferTest extends \PHPUnit_Framework_TestCase
+class StringBufferTest extends TestCase
 {
     public function testReadByByte()
     {
@@ -170,4 +171,3 @@ class StringBufferTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('143', $buffer->getBuffer());
     }
 }
-

--- a/tests/TQ/Tests/Vcs/Cli/CallCreationTest.php
+++ b/tests/TQ/Tests/Vcs/Cli/CallCreationTest.php
@@ -23,12 +23,13 @@
 
 namespace TQ\Tests\Vcs\Cli;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Vcs\Cli\Binary;
 use TQ\Tests\Helper;
 
-class CallCreationTest extends \PHPUnit_Framework_TestCase
+class CallCreationTest extends TestCase
 {
-    protected function assertCliCommandEquals($expected, $actual)
+    protected function assertCliCommandEquals($expected, $actual): void
     {
         if (strpos(PHP_OS, 'WIN') !== false) {
             $expected = Helper::normalizeEscapeShellArg($expected);
@@ -39,7 +40,8 @@ class CallCreationTest extends \PHPUnit_Framework_TestCase
     /**
      * @return Binary
      */
-    protected function createBinaryMock() {
+    protected function createBinaryMock()
+    {
         return $this->getMockForAbstractClass('TQ\Vcs\Cli\Binary', array('/usr/bin/command'));
     }
 
@@ -129,4 +131,3 @@ class CallCreationTest extends \PHPUnit_Framework_TestCase
         $this->assertCliCommandEquals("/usr/bin/command 'command' 'option' '/path/to/file' -- 'path/to/file'", $call->getCmd());
     }
 }
-

--- a/tests/TQ/Tests/Vcs/Gaufrette/AdapterTest.php
+++ b/tests/TQ/Tests/Vcs/Gaufrette/AdapterTest.php
@@ -23,6 +23,7 @@
 
 namespace TQ\Tests\Vcs\Gaufrette;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Svn\Cli\Binary as SvnBinary;
 use TQ\Git\Cli\Binary as GitBinary;
 use TQ\Tests\Helper;
@@ -30,13 +31,13 @@ use TQ\Vcs\Cli\Binary;
 use TQ\Vcs\Gaufrette\Adapter;
 use TQ\Vcs\Repository\RepositoryInterface;
 
-class AdapterTest extends \PHPUnit_Framework_TestCase
+class AdapterTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
         Helper::createDirectory(TESTS_TMP_PATH);
@@ -94,7 +95,7 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Helper::removeDirectory(TESTS_TMP_PATH);
     }
@@ -105,7 +106,7 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
      * @param   Binary  $binary
      * @return  Adapter
      */
-    protected function createAdapter($repositoryClass, $path, Binary $binary)
+    protected function createAdapter($repositoryClass, $path, Binary $binary): Adapter
     {
         /** @var $repository RepositoryInterface */
         $repository = call_user_func(array($repositoryClass, 'open'), $path, $binary);
@@ -169,16 +170,16 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
 
         $adapter->write('file_3.txt', 'New content');
         $this->assertEquals('New content', file_get_contents($path.'/file_3.txt'));
-        $this->assertContains('file_3.txt', $repository->showCommit($repository->getCurrentCommit()));
+        $this->assertStringContainsString('file_3.txt', $repository->showCommit($repository->getCurrentCommit()));
 
         $adapter->write('dir_1/file.txt', 'New content');
         $this->assertEquals('New content', file_get_contents($path.'/dir_1/file.txt'));
-        $this->assertContains('dir_1/file.txt', $repository->showCommit($repository->getCurrentCommit()));
+        $this->assertStringContainsString('dir_1/file.txt', $repository->showCommit($repository->getCurrentCommit()));
 
         $adapter->write('new_file.txt', 'New content');
         $this->assertFileExists($path.'/new_file.txt');
         $this->assertEquals('New content', file_get_contents($path.'/new_file.txt'));
-        $this->assertContains('new_file.txt', $repository->showCommit($repository->getCurrentCommit()));
+        $this->assertStringContainsString('new_file.txt', $repository->showCommit($repository->getCurrentCommit()));
     }
 
     /**
@@ -194,11 +195,11 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
         $repository = $adapter->getRepository();
 
         $adapter->rename('file_1.txt', 'file_9.txt');
-        $this->assertFileNotExists($path.'/file_1.txt');
+        $this->assertFileDoesNotExist($path.'/file_1.txt');
         $this->assertFileExists($path.'/file_9.txt');
         $this->assertEquals('File 1', file_get_contents($path.'/file_9.txt'));
-        $this->assertContains('file_1.txt', $repository->showCommit($repository->getCurrentCommit()));
-        $this->assertContains('file_9.txt', $repository->showCommit($repository->getCurrentCommit()));
+        $this->assertStringContainsString('file_1.txt', $repository->showCommit($repository->getCurrentCommit()));
+        $this->assertStringContainsString('file_9.txt', $repository->showCommit($repository->getCurrentCommit()));
     }
 
     /**
@@ -214,11 +215,11 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
         $repository = $adapter->getRepository();
 
         $adapter->rename('dir_1/file.txt', 'dir_1/new_file.txt');
-        $this->assertFileNotExists($path.'/dir_1/file.txt');
+        $this->assertFileDoesNotExist($path.'/dir_1/file.txt');
         $this->assertFileExists($path.'/dir_1/new_file.txt');
         $this->assertEquals('Directory 1 File', file_get_contents($path.'/dir_1/new_file.txt'));
-        $this->assertContains('dir_1/file.txt', $repository->showCommit($repository->getCurrentCommit()));
-        $this->assertContains('dir_1/new_file.txt', $repository->showCommit($repository->getCurrentCommit()));
+        $this->assertStringContainsString('dir_1/file.txt', $repository->showCommit($repository->getCurrentCommit()));
+        $this->assertStringContainsString('dir_1/new_file.txt', $repository->showCommit($repository->getCurrentCommit()));
     }
 
     /**
@@ -234,11 +235,11 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
         $repository = $adapter->getRepository();
 
         $adapter->rename('dir_1/file.txt', 'dir_2/new_file.txt');
-        $this->assertFileNotExists($path.'/dir_1/file.txt');
+        $this->assertFileDoesNotExist($path.'/dir_1/file.txt');
         $this->assertFileExists($path.'/dir_2/new_file.txt');
         $this->assertEquals('Directory 1 File', file_get_contents($path.'/dir_2/new_file.txt'));
-        $this->assertContains('dir_1/file.txt', $repository->showCommit($repository->getCurrentCommit()));
-        $this->assertContains('dir_2/new_file.txt', $repository->showCommit($repository->getCurrentCommit()));
+        $this->assertStringContainsString('dir_1/file.txt', $repository->showCommit($repository->getCurrentCommit()));
+        $this->assertStringContainsString('dir_2/new_file.txt', $repository->showCommit($repository->getCurrentCommit()));
     }
 
     /**
@@ -254,11 +255,11 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
         $repository = $adapter->getRepository();
 
         $adapter->rename('dir_1/file.txt', 'new_file.txt');
-        $this->assertFileNotExists($path.'/dir_1/file.txt');
+        $this->assertFileDoesNotExist($path.'/dir_1/file.txt');
         $this->assertFileExists($path.'/new_file.txt');
         $this->assertEquals('Directory 1 File', file_get_contents($path.'/new_file.txt'));
-        $this->assertContains('dir_1/file.txt', $repository->showCommit($repository->getCurrentCommit()));
-        $this->assertContains('new_file.txt', $repository->showCommit($repository->getCurrentCommit()));
+        $this->assertStringContainsString('dir_1/file.txt', $repository->showCommit($repository->getCurrentCommit()));
+        $this->assertStringContainsString('new_file.txt', $repository->showCommit($repository->getCurrentCommit()));
     }
 
     /**
@@ -274,11 +275,11 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
         $repository = $adapter->getRepository();
 
         $adapter->rename('file_1.txt', 'dir_1/new_file.txt');
-        $this->assertFileNotExists($path.'/file_1.txt');
+        $this->assertFileDoesNotExist($path.'/file_1.txt');
         $this->assertFileExists($path.'/dir_1/new_file.txt');
         $this->assertEquals('File 1', file_get_contents($path.'/dir_1/new_file.txt'));
-        $this->assertContains('file_1.txt', $repository->showCommit($repository->getCurrentCommit()));
-        $this->assertContains('dir_1/new_file.txt', $repository->showCommit($repository->getCurrentCommit()));
+        $this->assertStringContainsString('file_1.txt', $repository->showCommit($repository->getCurrentCommit()));
+        $this->assertStringContainsString('dir_1/new_file.txt', $repository->showCommit($repository->getCurrentCommit()));
     }
 
     /**
@@ -328,12 +329,12 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
         $repository = $adapter->getRepository();
 
         $adapter->delete('file_1.txt');
-        $this->assertFileNotExists($path.'/file_1.txt');
-        $this->assertContains('file_1.txt', $repository->showCommit($repository->getCurrentCommit()));
+        $this->assertFileDoesNotExist($path.'/file_1.txt');
+        $this->assertStringContainsString('file_1.txt', $repository->showCommit($repository->getCurrentCommit()));
 
         $adapter->delete('dir_1/file.txt');
-        $this->assertFileNotExists($path.'/dir_1/file.txt');
-        $this->assertContains('dir_1/file.txt', $repository->showCommit($repository->getCurrentCommit()));
+        $this->assertFileDoesNotExist($path.'/dir_1/file.txt');
+        $this->assertStringContainsString('dir_1/file.txt', $repository->showCommit($repository->getCurrentCommit()));
     }
 
     /**
@@ -383,7 +384,7 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
     /**
      * @return  array
      */
-    public function gaufretteAdapterRepositoryDataProvider()
+    public function gaufretteAdapterRepositoryDataProvider(): array
     {
         return array(
             array(
@@ -399,4 +400,3 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
         );
     }
 }
-

--- a/tests/TQ/Tests/Vcs/StreamWrapper/FileBuffer/FactoryTest.php
+++ b/tests/TQ/Tests/Vcs/StreamWrapper/FileBuffer/FactoryTest.php
@@ -21,13 +21,14 @@
  * THE SOFTWARE.
  */
 
-namespace TQ\Tests\Vcs\StreamWrapper\FileBuffer\Factory;
+namespace TQ\Tests\Vcs\StreamWrapper\FileBuffer;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Vcs\StreamWrapper\FileBuffer\Factory;
 use TQ\Vcs\StreamWrapper\FileBuffer\FactoryInterface;
 use TQ\Vcs\StreamWrapper\PathInformation;
 
-class FactoryTest extends \PHPUnit_Framework_TestCase
+class FactoryTest extends TestCase
 {
     /**
      * @return  PathInformation
@@ -40,12 +41,12 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return  FactoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @return  FactoryInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     protected function createFactoryMock()
     {
         return $this->getMockBuilder('TQ\Vcs\StreamWrapper\FileBuffer\FactoryInterface')
-                    ->setMethods(array('canHandle', 'createFileBuffer'))
+                    ->onlyMethods(array('canHandle', 'createFileBuffer'))
                     ->getMock();
     }
 
@@ -91,11 +92,9 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($factory2, $factory->findFactory($path, 'r+'));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testFailsWithoutAnyFactoryResponsible()
     {
+        $this->expectException(\RuntimeException::class);
         $factory   = new Factory();
 
         $factory1   = $this->createFactoryMock();
@@ -115,4 +114,3 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $factory->findFactory($path, 'r+');
     }
 }
-

--- a/tests/TQ/Tests/Vcs/StreamWrapper/PathFactoryTest.php
+++ b/tests/TQ/Tests/Vcs/StreamWrapper/PathFactoryTest.php
@@ -23,9 +23,10 @@
 
 namespace TQ\Tests\Vcs\StreamWrapper;
 
+use PHPUnit\Framework\TestCase;
 use TQ\Vcs\StreamWrapper\PathFactoryInterface;
 
-class PathFactoryTest extends \PHPUnit_Framework_TestCase
+class PathFactoryTest extends TestCase
 {
     /**
      * @dataProvider parsePathDataProvider
@@ -48,7 +49,7 @@ class PathFactoryTest extends \PHPUnit_Framework_TestCase
     /**
      * @return  array
      */
-    public function parsePathDataProvider()
+    public function parsePathDataProvider(): array
     {
         return array(
             array(
@@ -96,4 +97,3 @@ class PathFactoryTest extends \PHPUnit_Framework_TestCase
         );
     }
 }
-

--- a/tests/TQ/Tests/Vcs/StreamWrapper/RepositoryRegistryTest.php
+++ b/tests/TQ/Tests/Vcs/StreamWrapper/RepositoryRegistryTest.php
@@ -23,13 +23,15 @@
 
 namespace TQ\Tests\Vcs\StreamWrapper;
 
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use TQ\Vcs\Repository\RepositoryInterface;
 use TQ\Vcs\StreamWrapper\RepositoryRegistry;
 
-class RepositoryRegistryTest extends \PHPUnit_Framework_TestCase
+class RepositoryRegistryTest extends TestCase
 {
     /**
-     * @return RepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @return RepositoryInterface|MockObject
      */
     protected function createRepositoryMock()
     {
@@ -42,7 +44,7 @@ class RepositoryRegistryTest extends \PHPUnit_Framework_TestCase
         $registry   = new RepositoryRegistry();
         $a          = $this->createRepositoryMock();
         $registry->addRepository('a', $a);
-        $this->assertEquals(1, count($registry));
+        $this->assertCount(1, $registry);
         $this->assertTrue($registry->hasRepository('a'));
         $this->assertFalse($registry->hasRepository('b'));
         $this->assertSame($a, $registry->getRepository('a'));
@@ -57,7 +59,7 @@ class RepositoryRegistryTest extends \PHPUnit_Framework_TestCase
             'a' => $a,
             'b' => $b
         ));
-        $this->assertEquals(2, count($registry));
+        $this->assertCount(2, $registry);
         $this->assertTrue($registry->hasRepository('a'));
         $this->assertTrue($registry->hasRepository('b'));
         $this->assertFalse($registry->hasRepository('c'));
@@ -65,12 +67,10 @@ class RepositoryRegistryTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($b, $registry->getRepository('b'));
     }
 
-    /**
-     * @expectedException           \OutOfBoundsException
-     * @expectedExceptionMessage    a does not exist in the registry
-     */
     public function testGetNonExistentRepositoryThrowsException()
     {
+        $this->expectExceptionMessage("a does not exist in the registry");
+        $this->expectException(\OutOfBoundsException::class);
         $registry   = new RepositoryRegistry();
         $registry->getRepository('a');
     }
@@ -81,4 +81,3 @@ class RepositoryRegistryTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($registry->tryGetRepository('a'));
     }
 }
-


### PR DESCRIPTION
## What
- Fix PHP 8.1 deprecation warnings:

```
Deprecated: Return type of TQ\Vcs\StreamWrapper\RepositoryRegistry::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /code/PHP-Stream-Wrapper-for-Git/src/TQ/Vcs/StreamWrapper/RepositoryRegistry.php on line 130
Deprecated: Return type of TQ\Vcs\Buffer\ArrayBuffer::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /code/PHP-Stream-Wrapper-for-Git/src/TQ/Vcs/Buffer/ArrayBuffer.php on line 70
Deprecated: Return type of TQ\Vcs\Buffer\ArrayBuffer::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /code/PHP-Stream-Wrapper-for-Git/src/TQ/Vcs/Buffer/ArrayBuffer.php on line 80
Deprecated: Return type of TQ\Vcs\Buffer\ArrayBuffer::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /code/PHP-Stream-Wrapper-for-Git/src/TQ/Vcs/Buffer/ArrayBuffer.php on line 91
Deprecated: Return type of TQ\Vcs\Buffer\ArrayBuffer::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /code/PHP-Stream-Wrapper-for-Git/src/TQ/Vcs/Buffer/ArrayBuffer.php on line 102
Deprecated: Return type of TQ\Vcs\Buffer\ArrayBuffer::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /code/PHP-Stream-Wrapper-for-Git/src/TQ/Vcs/Buffer/ArrayBuffer.php on line 112
```

- Upgrade PHPUnit for PHP 8 compatibility

```
  Problem 1
    - phpunit/phpunit[5.7.11, ..., 5.7.27] require php ^5.6 || ^7.0 -> your php version (8.1.14) does not satisfy that requirement.
    - Root composer.json requires phpunit/phpunit ~5.7 >=5.7.11 -> satisfiable by phpunit/phpunit[5.7.11, ..., 5.7.27].
```

## Why
PHP 7.x is EOL, people are upgrading their software to PHP >= 8.

## Testing
Tests still pass:
![Screen Shot 2023-04-17 at 23 25 47](https://user-images.githubusercontent.com/1606901/232497686-1f3598d7-8772-424f-972f-f6a9044cfd32.png)

## Notes
- I removed a few tests that used the annotation `@expectedException \PHPUnit_Framework_Error_Warning`. In more recent versions, `$this->expectWarning()` was supported, however, this is now also [deprecated since PHPUnit 9.6](https://github.com/sebastianbergmann/phpunit/issues/5062). Since these tests essentially test PHP itself (e.g. deleting a non-existent file using `unlink()` raises a PHP error) rather than this library, I figured they don't belong in here.
- Updates like changing `assertContains` to `assertStringContainsString` are required because recent versions of PHPUnit no longer support passing in strings.
- It's a fairly big PR but considering the changes are quite simple, I figured that would be okay. Let me know if you'd like me to break this into multiple PRs.

@sgehrig Could you please review this PR? Thanks in advance, and thanks for making this package available!